### PR TITLE
Css 3166: Prepare charm for publication on Charmhub

### DIFF
--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -1,0 +1,26 @@
+name: Promote charm
+
+on:
+  workflow_dispatch:
+    inputs:
+      origin-channel:
+        type: choice
+        description: 'Origin Channel'
+        options:
+        - latest/edge
+      destination-channel:
+        type: choice
+        description: 'Destination Channel'
+        options:
+        - latest/stable
+    secrets:
+      CHARMHUB_TOKEN:
+        required: true
+
+jobs:
+  promote-charm:
+    uses: canonical/operator-workflows/.github/workflows/promote_charm.yaml@main
+    with:
+      origin-channel: ${{ github.event.inputs.origin-channel }}
+      destination-channel: ${{ github.event.inputs.destination-channel }}
+    secrets: inherit

--- a/.github/workflows/test_and_publish_charm.yaml
+++ b/.github/workflows/test_and_publish_charm.yaml
@@ -1,0 +1,22 @@
+name: Publish to edge
+
+# On push to a "special" branch, we:
+# * always publish to charmhub at latest/edge/branchname
+# * always run tests
+# where a "special" branch is one of main/master or track/**, as
+# by convention these branches are the source for a corresponding
+# charmhub edge channel.
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - track/**
+
+jobs:
+  publish-to-edge:
+    uses: canonical/operator-workflows/.github/workflows/test_and_publish_charm.yaml@main
+    secrets: inherit
+    with:
+      trivy-image-config: "trivy.yaml"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ For a local deployment, follow the following steps:
     juju relate temporal-k8s:visibility postgresql-k8s:db
 
     # Relate operator to temporal-admin-k8s (Navigate to temporal-admin-k8s directory):
-    juju deploy ./temporal-admin-k8s_ubuntu-22.04-amd64.charm --resource temporal-admin-image=temporalio/admin-tools
+    juju deploy temporal-admin-k8s --channel edge
     juju relate temporal-k8s:admin temporal-admin-k8s:admin
 
     # Create default namespace:
@@ -133,7 +133,7 @@ You will need to modify the ingress resource to accept gRPC traffic. This can be
 
 ```bash
 # Edit the ingress resource
-kubectl edit ingress -n <NAMESPACE>
+kubectl edit ingress -n <MODEL_NAME>
 
 ## Add the following line under annotations
 nginx.ingress.kubernetes.io/backend-protocol: GRPC
@@ -149,7 +149,7 @@ kubectl exec -it -n ingress <INGRESS_CONTROLLER_NAME> -- bash
 # Modify nginx config file
 nano nginx.conf
 
-# Navigate to ## start server and ensure that the lines relating to port 80 have http2 at the end
+# Navigate to "## start server" and ensure that the lines relating to port 80 have http2 at the end
 listen 80 default_server reuseport backlog=4096 http2;
 listen [::]:80 default_server reuseport backlog=4096 http2;
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ wraps the versions distributed by
 
 ## Usage
 
+Note: This operator requires the use of juju>=3.1.
+
 ### Deploying PostgreSQL Database
 
 The Temporal and PostgreSQL operators can be deployed and connected to each
@@ -29,9 +31,10 @@ juju relate temporal-k8s:visibility postgresql-k8s:db
 ```
 
 ### Deploying Temporal Admin
-Once the [Temporal Admin operator](https://github.com/canonical/temporal-admin-k8s-operator) is deployed, it can be connected to the Temporal operator using the Juju command line as follows:
+On initial deployment, the Temporal operator requires integration with the [Temporal Admin operator](https://github.com/canonical/temporal-admin-k8s-operator) for schema creation. Once the Temporal Admin operator is deployed, it can be connected to the Temporal operator using the Juju command line as follows:
 
 ```bash
+juju deploy temporal-admin-k8s
 juju relate temporal-k8s:admin temporal-admin-k8s:admin
 ```
 
@@ -39,13 +42,24 @@ juju relate temporal-k8s:admin temporal-admin-k8s:admin
 The Temporal operator exposes itself using the [Nginx Ingress Integrator](https://charmhub.io/nginx-ingress-integrator) operator. You must first make sure to have an [Nginx Ingress Controller](https://docs.nginx.com/nginx-ingress-controller/) deployed. This operator can then be deployed and connected to the Temporal operator using the Juju command line as follows:
 
 ```bash
+# Deploy ingress controller.
+microk8s enable ingress
+
 juju deploy nginx-ingress-integrator
 juju relate temporal-k8s:ingress nginx-ingress-integrator:ingress
-juju config temporal-k8s external-hostname=<YOUR_HOSTNAME>
 ```
+
+Once deployed, the hostname will default to the name of the application (```temporal-k8s```), and can be configured using the ```external-hostname``` configuration on the Temporal operator.
+
+Note: The Temporal operator currently does not support TLS functionality. As such, please check [CONTRIBUTING.md](./CONTRIBUTING.md) for instructions on how to enable insecure HTTP/2 connections on port 80 as a temporary workaround.
+
+## Verifying
+To verify that the setup is running correctly, run ```juju status --relations --watch 1s``` and ensure that all pods are active and all required integrations exist.
+
+To run a basic workflow, you may use a simple client (e.g. [sdk-python sample](https://github.com/temporalio/sdk-python#quick-start)) and connect to the hostname specified in the previous steps (by default, your client should connect to ```temporal-k8s:80```).
 
 ## Contributing
 
 This charm is still in active development. Please see the
 [Juju SDK docs](https://juju.is/docs/sdk) for guidelines on enhancements to this charm
-following best practice guidelines, and `CONTRIBUTING.md` for developer guidance.
+following best practice guidelines, and [CONTRIBUTING.md](./CONTRIBUTING.md) for developer guidance.

--- a/icon.svg
+++ b/icon.svg
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="100px"
+   height="100px"
+   viewBox="0 0 100 100"
+   version="1.1"
+   id="svg18"
+   sodipodi:docname="icon.svg"
+   inkscape:version="1.2.2 (732a01da63, 2022-12-09, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <metadata
+     id="metadata22">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>eclispe-che</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1206"
+     inkscape:window-height="736"
+     id="namedview20"
+     showgrid="false"
+     inkscape:pagecheckerboard="true"
+     inkscape:zoom="4.72"
+     inkscape:cx="45.338983"
+     inkscape:cy="57.521186"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <!-- Generator: Sketch 45.2 (43514) - http://www.bohemiancoding.com/sketch -->
+  <title
+     id="title2">eclispe-che</title>
+  <desc
+     id="desc4">Created with Sketch.</desc>
+  <defs
+     id="defs7">
+    <path
+       d="M50.0004412,4.04252804e-14 C22.3871247,4.04252804e-14 0,22.3848726 0,49.9995588 C0,77.6133626 22.3871247,100 50.0004412,100 C77.6137577,100 100,77.6133626 100,49.9995588 C100,22.3848726 77.6128753,3.55271368e-14 50.0004412,4.04252804e-14 Z"
+       id="path-1" />
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath414">
+      <rect
+         style="opacity:0.5;fill:#000000;stroke-width:10.613"
+         id="rect416"
+         width="521.27826"
+         height="440.85867"
+         x="674.51324"
+         y="368.65756" />
+    </clipPath>
+  </defs>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="BACKGROUND">
+    <g
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-opacity:1"
+       id="Page-1">
+      <g
+         id="eclispe-che"
+         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1">
+        <g
+           id="path3023-path"
+           style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1">
+          <use
+             xlink:href="#path-1"
+             id="use9"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-opacity:1"
+             x="0"
+             y="0"
+             width="100%"
+             height="100%" />
+          <path
+             d="M 50.000441,0.5 C 22.662621,0.5 0.5,22.661661 0.5,49.999559 0.5,77.337051 22.663098,99.5 50.000441,99.5 77.337613,99.5 99.5,77.337222 99.5,49.999559 99.5,22.661796 77.337514,0.5 50.000441,0.5 Z"
+             id="path11"
+             style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+    </g>
+    <g
+       id="g228"
+       transform="matrix(0.21943857,0,0,0.21943857,-153.8929,-79.487101)"
+       clip-path="url(#clipPath414)">
+      <g
+         id="g224">
+        <polygon
+           class="st0"
+           points="466.6,913.6 524.4,913.6 524.4,895.8 389.9,895.8 389.9,913.6 447.5,913.6 447.5,1064.2 466.6,1064.2 "
+           id="polygon208"
+           style="fill:#141414" />
+        <path
+           class="st0"
+           d="m 791.7,942.6 c -17.7,0 -30.6,7.2 -38.6,21.3 -6.2,-14.2 -17.9,-21.3 -34.7,-21.3 -13.6,0 -24.4,4.8 -31.5,14.1 v -12.1 h -18 l 0.2,119.7 h 18.5 v -57.6 c 0,-31.9 9.3,-47.5 28.4,-47.5 16.9,0 25.5,12.1 25.5,36 v 69.1 H 760 v -57.6 c 0,-31.9 9.6,-47.5 29.3,-47.5 24.8,0 24.8,24.6 24.8,35.1 v 70 h 18.5 v -74.5 c 0,-30.9 -14.1,-47.2 -40.9,-47.2 z"
+           id="path210"
+           style="fill:#141414" />
+        <path
+           class="st0"
+           d="m 578.6,942.6 c -36.8,0 -53.3,31.3 -53.3,62.4 0,37.2 21.7,61.2 55.2,61.2 19.3,0 32.7,-5.8 46.3,-20.1 l 0.7,-0.8 -13,-11.3 -0.7,0.7 c -9.7,10.3 -19.3,14.5 -33.2,14.5 -22.4,0 -36.1,-14.7 -36.9,-39.3 h 86 l 0.1,-0.8 c 0.4,-2.7 0.7,-6.7 0.7,-10.4 0,-14.7 -4.3,-28.2 -12.2,-38.1 -9.1,-11.8 -22.9,-18 -39.7,-18 z m 0,15.8 c 19.8,0 32.8,12.5 34.1,32.7 0,1.2 0.1,2.2 0.1,2.8 h -69 c 1.9,-21.2 15.8,-35.5 34.8,-35.5 z"
+           id="path212"
+           style="fill:#141414" />
+        <path
+           class="st0"
+           d="m 1425,1047.9 v -152 h -17.4 v 153.4 c 0,8.7 7.2,15.7 16,15.7 h 27.6 v -17 H 1425 Z"
+           id="path214"
+           style="fill:#141414" />
+        <path
+           class="st0"
+           d="m 1314,942.6 c -20.4,0 -35.9,7.8 -48.8,24.5 l -0.6,0.8 13.5,11.3 0.6,-0.9 c 9.5,-13.1 20.6,-19.2 35,-19.2 19.3,0 29.6,10.6 29.6,30.8 v 4.5 h -23.1 c -22.9,0 -36,2.1 -45.2,7.3 -9.2,5.7 -14.1,15.2 -14.1,27.4 0,23.2 15.6,37.1 41.6,37.1 17.9,0 31.8,-6.1 41.4,-18.3 l 0.9,16.3 h 17 v -74.3 c 0,-14.7 -4.3,-26.7 -12.6,-34.9 -8.2,-8.1 -20.4,-12.4 -35.2,-12.4 z m 29.3,67.2 v 0.7 c 0,24.7 -13.8,40.1 -36,40.1 -17.2,0 -27.9,-7.9 -27.9,-20.5 0,-6.5 2,-11.4 6.1,-14.5 5.4,-4.3 14.6,-5.8 36.2,-5.8 z"
+           id="path216"
+           style="fill:#141414" />
+        <path
+           class="st0"
+           d="m 934.5,942.4 c -15.7,0 -28.8,5.6 -37.9,16.1 v -14 H 878.1 V 1113 h 18.5 v -62.7 c 9.2,10.4 22.2,15.9 37.9,15.9 32.9,0 53.3,-23.7 53.3,-61.9 0,-18.4 -4.9,-34 -14.1,-44.9 -9.4,-11.1 -22.9,-17 -39.2,-17 z m 34.9,61.9 c 0,13.3 -3.3,24.6 -9.5,32.6 -6.5,8.3 -16.1,12.7 -27.7,12.7 -22.8,0 -37,-17.4 -37,-45.3 0,-27.9 14.2,-45.3 37,-45.3 22.9,-0.1 37.2,17.3 37.2,45.3 z"
+           id="path218"
+           style="fill:#141414" />
+        <path
+           class="st0"
+           d="m 1074.5,942.6 c -16.4,0 -31.2,6.2 -41.5,17.6 -10.2,11.2 -15.8,26.8 -15.8,44.1 0,17.3 5.6,33 15.8,44.2 10.4,11.4 25.1,17.7 41.5,17.7 33.4,0 57.6,-26 57.6,-61.9 0,-17.2 -5.7,-32.9 -16,-44.1 -10.5,-11.4 -25.3,-17.6 -41.6,-17.6 z m 39.1,61.7 c 0,12.8 -3.7,24.3 -10.3,32.4 -7,8.5 -17,13 -28.8,13 -23.6,0 -38.9,-17.8 -38.9,-45.3 0,-27.4 15.3,-45.1 38.9,-45.1 23.7,-0.1 39.1,17.6 39.1,45 z"
+           id="path220"
+           style="fill:#141414" />
+        <path
+           class="st0"
+           d="m 1223,942.6 c -10.5,0 -24.6,3 -33.9,17 v -15.1 h -18.5 v 119.7 h 18.5 v -66.7 c 0,-23.5 11.7,-38.2 30.5,-38.2 4.8,0 9.6,1.1 15.1,3.5 l 0.8,0.3 9.1,-15 -0.9,-0.5 c -6.1,-3.3 -12.9,-5 -20.7,-5 z"
+           id="path222"
+           style="fill:#141414" />
+      </g>
+      <path
+         class="st0"
+         d="m 999.1,518.2 c -9.2,-68.8 -32.4,-126.3 -68.2,-126.3 -35.7,0 -59,57.5 -68.2,126.3 -68.8,9.2 -126.3,32.4 -126.3,68.2 0,35.7 57.5,59 126.3,68.2 9.2,68.8 32.4,126.3 68.2,126.3 35.7,0 59,-57.5 68.2,-126.3 68.8,-9.2 126.3,-32.4 126.3,-68.2 0,-35.8 -57.5,-59.1 -126.3,-68.2 z M 860.5,634.4 c -65.9,-9.5 -104.4,-31.3 -104.4,-48.1 0,-16.8 38.4,-38.6 104.4,-48.1 -1.5,15.9 -2.2,32.1 -2.2,48.1 0,16 0.7,32.3 2.2,48.1 z m 70.4,-222.9 c 16.8,0 38.6,38.4 48.1,104.4 -15.9,-1.5 -32.1,-2.2 -48.1,-2.2 -16,0 -32.2,0.8 -48.1,2.2 9.5,-65.9 31.3,-104.4 48.1,-104.4 z m 70.4,222.9 c -3.2,0.5 -16.6,2 -19.9,2.4 -0.3,3.4 -1.9,16.7 -2.4,19.9 -9.5,65.9 -31.3,104.4 -48.1,104.4 -16.8,0 -38.6,-38.4 -48.1,-104.4 -0.5,-3.2 -2,-16.6 -2.4,-19.9 -1.5,-15.6 -2.5,-32.4 -2.5,-50.5 0,-18.1 0.9,-34.8 2.5,-50.5 15.6,-1.5 32.4,-2.5 50.5,-2.5 18.1,0 34.8,0.9 50.5,2.5 3.4,0.3 16.7,1.9 19.9,2.4 65.9,9.5 104.4,31.3 104.4,48.1 0,16.8 -38.5,38.6 -104.4,48.1 z"
+         id="path226"
+         style="fill:#141414" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="PLACE LOGO HERE" />
+</svg>

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -5,7 +5,7 @@
 # https://juju.is/docs/sdk/metadata-reference
 
 name: temporal-k8s
-display-name: Temporal server
+display-name: Temporal Server
 summary: Temporal server operator
 description: |
   Temporal is a developer-first, open source platform that ensures
@@ -16,6 +16,10 @@ tags:
   - task
   - activities
   - development
+issues: https://github.com/canonical/temporal-k8s-operator/issues
+assumes:
+  - juju >= 3.1
+  - k8s-api
 
 peers:
   temporal:

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,0 +1,3 @@
+timeout: 20m
+scan:
+  offline-scan: true


### PR DESCRIPTION
This PR is meant to finalize the charm resources which will be published to [Charmhub](https://charmhub.io/). The main changes made were adding CI/CD github actions for promoting the charm's channel on Charmhub, and polishing the README.md file to improve on the deployment instructions. (Note: this charm should now be considered "Stage 1: Publication Ready" in line with the [Definition of Great Charms](https://docs.google.com/document/d/1aB7YrnVEqXWgzhZXQf6gOWZnbV9THjvTrW0KlCuLUpg/edit#heading=h.xc0m9jobc7ma)).