### PR TITLE
CSS-3775: update pgsql interface to modern postgresql_client interface

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,0 +1,35 @@
+header:
+  license:
+    spdx-id: Apache-2.0
+    copyright-owner: Canonical Ltd.
+    content: |
+      Copyright [year] [owner]
+      See LICENSE file for licensing details.
+  paths:
+    - '**'
+  paths-ignore:
+    - '.github/**'
+    - '**/.gitkeep'
+    - '**/*.cfg'
+    - '**/*.conf'
+    - '**/*.j2'
+    - '**/*.json'
+    - '**/*.md'
+    - '**/*.rule'
+    - '**/*.tmpl'
+    - '**/*.txt'
+    - '.codespellignore'
+    - '.dockerignore'
+    - '.flake8'
+    - '.jujuignore'
+    - '.gitignore'
+    - '.licenserc.yaml'
+    - '.trivyignore'
+    - '.woke.yaml'
+    - '.woke.yml'
+    - 'CODEOWNERS'
+    - 'icon.svg'
+    - 'LICENSE'
+    - 'trivy.yaml'
+    - 'lib/**'
+  comment: on-failure

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -18,6 +18,7 @@ header:
     - '**/*.rule'
     - '**/*.tmpl'
     - '**/*.txt'
+    - '**/*.jinja'
     - '.codespellignore'
     - '.dockerignore'
     - '.flake8'

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -34,3 +34,4 @@ header:
     - 'trivy.yaml'
     - 'lib/**'
   comment: on-failure
+  

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,7 @@ deployment, follow the following steps:
     juju deploy ./temporal-ui-k8s_ubuntu-22.04-amd64.charm --resource temporal-ui-image=temporalio/ui:2.10.3
 
     # Relate operator to postgres:
-    juju deploy postgresql-k8s --channel edge --trust
+    juju deploy postgresql-k8s --channel 14/stable --trust
     juju relate temporal-k8s:db postgresql-k8s:database
     juju relate temporal-k8s:visibility postgresql-k8s:database
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ other using the Juju command line as follows:
 ```bash
 juju deploy temporal-k8s
 juju deploy postgresql-k8s --channel edge --trust
-juju relate temporal-k8s:db postgresql-k8s:db
-juju relate temporal-k8s:visibility postgresql-k8s:db
+juju relate temporal-k8s:db postgresql-k8s:database
+juju relate temporal-k8s:visibility postgresql-k8s:database
 ```
 
 ### Deploying Temporal Admin

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ other using the Juju command line as follows:
 
 ```bash
 juju deploy temporal-k8s
-juju deploy postgresql-k8s --channel edge --trust
+juju deploy postgresql-k8s --channel 14/stable --trust
 juju relate temporal-k8s:db postgresql-k8s:database
 juju relate temporal-k8s:visibility postgresql-k8s:database
 ```

--- a/actions.yaml
+++ b/actions.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 restart:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 # Learn more about charmcraft.yaml configuration at:

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 options:

--- a/lib/charms/data_platform_libs/v0/database_requires.py
+++ b/lib/charms/data_platform_libs/v0/database_requires.py
@@ -1,0 +1,502 @@
+# Copyright 2022 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""[DEPRECATED] Relation 'requires' side abstraction for database relation.
+
+This library is a uniform interface to a selection of common database
+metadata, with added custom events that add convenience to database management,
+and methods to consume the application related data.
+
+Following an example of using the DatabaseCreatedEvent, in the context of the
+application charm code:
+
+```python
+
+from charms.data_platform_libs.v0.database_requires import (
+    DatabaseCreatedEvent,
+    DatabaseRequires,
+)
+
+class ApplicationCharm(CharmBase):
+    # Application charm that connects to database charms.
+
+    def __init__(self, *args):
+        super().__init__(*args)
+
+        # Charm events defined in the database requires charm library.
+        self.database = DatabaseRequires(self, relation_name="database", database_name="database")
+        self.framework.observe(self.database.on.database_created, self._on_database_created)
+
+    def _on_database_created(self, event: DatabaseCreatedEvent) -> None:
+        # Handle the created database
+
+        # Create configuration file for app
+        config_file = self._render_app_config_file(
+            event.username,
+            event.password,
+            event.endpoints,
+        )
+
+        # Start application with rendered configuration
+        self._start_application(config_file)
+
+        # Set active status
+        self.unit.status = ActiveStatus("received database credentials")
+```
+
+As shown above, the library provides some custom events to handle specific situations,
+which are listed below:
+
+— database_created: event emitted when the requested database is created.
+— endpoints_changed: event emitted when the read/write endpoints of the database have changed.
+— read_only_endpoints_changed: event emitted when the read-only endpoints of the database
+  have changed. Event is not triggered if read/write endpoints changed too.
+
+If it is needed to connect multiple database clusters to the same relation endpoint
+the application charm can implement the same code as if it would connect to only
+one database cluster (like the above code example).
+
+To differentiate multiple clusters connected to the same relation endpoint
+the application charm can use the name of the remote application:
+
+```python
+
+def _on_database_created(self, event: DatabaseCreatedEvent) -> None:
+    # Get the remote app name of the cluster that triggered this event
+    cluster = event.relation.app.name
+```
+
+It is also possible to provide an alias for each different database cluster/relation.
+
+So, it is possible to differentiate the clusters in two ways.
+The first is to use the remote application name, i.e., `event.relation.app.name`, as above.
+
+The second way is to use different event handlers to handle each cluster events.
+The implementation would be something like the following code:
+
+```python
+
+from charms.data_platform_libs.v0.database_requires import (
+    DatabaseCreatedEvent,
+    DatabaseRequires,
+)
+
+class ApplicationCharm(CharmBase):
+    # Application charm that connects to database charms.
+
+    def __init__(self, *args):
+        super().__init__(*args)
+
+        # Define the cluster aliases and one handler for each cluster database created event.
+        self.database = DatabaseRequires(
+            self,
+            relation_name="database",
+            database_name="database",
+            relations_aliases = ["cluster1", "cluster2"],
+        )
+        self.framework.observe(
+            self.database.on.cluster1_database_created, self._on_cluster1_database_created
+        )
+        self.framework.observe(
+            self.database.on.cluster2_database_created, self._on_cluster2_database_created
+        )
+
+    def _on_cluster1_database_created(self, event: DatabaseCreatedEvent) -> None:
+        # Handle the created database on the cluster named cluster1
+
+        # Create configuration file for app
+        config_file = self._render_app_config_file(
+            event.username,
+            event.password,
+            event.endpoints,
+        )
+        ...
+
+    def _on_cluster2_database_created(self, event: DatabaseCreatedEvent) -> None:
+        # Handle the created database on the cluster named cluster2
+
+        # Create configuration file for app
+        config_file = self._render_app_config_file(
+            event.username,
+            event.password,
+            event.endpoints,
+        )
+        ...
+
+```
+"""
+
+import json
+import logging
+from collections import namedtuple
+from datetime import datetime
+from typing import List, Optional
+
+from ops.charm import (
+    CharmEvents,
+    RelationChangedEvent,
+    RelationEvent,
+    RelationJoinedEvent,
+)
+from ops.framework import EventSource, Object
+from ops.model import Relation
+
+# The unique Charmhub library identifier, never change it
+LIBID = "0241e088ffa9440fb4e3126349b2fb62"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version.
+LIBPATCH = 5
+
+logger = logging.getLogger(__name__)
+
+
+class DatabaseEvent(RelationEvent):
+    """Base class for database events."""
+
+    @property
+    def endpoints(self) -> Optional[str]:
+        """Returns a comma separated list of read/write endpoints."""
+        return self.relation.data[self.relation.app].get("endpoints")
+
+    @property
+    def password(self) -> Optional[str]:
+        """Returns the password for the created user."""
+        return self.relation.data[self.relation.app].get("password")
+
+    @property
+    def read_only_endpoints(self) -> Optional[str]:
+        """Returns a comma separated list of read only endpoints."""
+        return self.relation.data[self.relation.app].get("read-only-endpoints")
+
+    @property
+    def replset(self) -> Optional[str]:
+        """Returns the replicaset name.
+
+        MongoDB only.
+        """
+        return self.relation.data[self.relation.app].get("replset")
+
+    @property
+    def tls(self) -> Optional[str]:
+        """Returns whether TLS is configured."""
+        return self.relation.data[self.relation.app].get("tls")
+
+    @property
+    def tls_ca(self) -> Optional[str]:
+        """Returns TLS CA."""
+        return self.relation.data[self.relation.app].get("tls-ca")
+
+    @property
+    def uris(self) -> Optional[str]:
+        """Returns the connection URIs.
+
+        MongoDB, Redis, OpenSearch and Kafka only.
+        """
+        return self.relation.data[self.relation.app].get("uris")
+
+    @property
+    def username(self) -> Optional[str]:
+        """Returns the created username."""
+        return self.relation.data[self.relation.app].get("username")
+
+    @property
+    def version(self) -> Optional[str]:
+        """Returns the version of the database.
+
+        Version as informed by the database daemon.
+        """
+        return self.relation.data[self.relation.app].get("version")
+
+
+class DatabaseCreatedEvent(DatabaseEvent):
+    """Event emitted when a new database is created for use on this relation."""
+
+
+class DatabaseEndpointsChangedEvent(DatabaseEvent):
+    """Event emitted when the read/write endpoints are changed."""
+
+
+class DatabaseReadOnlyEndpointsChangedEvent(DatabaseEvent):
+    """Event emitted when the read only endpoints are changed."""
+
+
+class DatabaseEvents(CharmEvents):
+    """Database events.
+
+    This class defines the events that the database can emit.
+    """
+
+    database_created = EventSource(DatabaseCreatedEvent)
+    endpoints_changed = EventSource(DatabaseEndpointsChangedEvent)
+    read_only_endpoints_changed = EventSource(DatabaseReadOnlyEndpointsChangedEvent)
+
+
+Diff = namedtuple("Diff", "added changed deleted")
+Diff.__doc__ = """
+A tuple for storing the diff between two data mappings.
+
+— added — keys that were added.
+— changed — keys that still exist but have new values.
+— deleted — keys that were deleted.
+"""
+
+
+class DatabaseRequires(Object):
+    """Requires-side of the database relation."""
+
+    on = DatabaseEvents()
+
+    def __init__(
+        self,
+        charm,
+        relation_name: str,
+        database_name: str,
+        extra_user_roles: str = None,
+        relations_aliases: List[str] = None,
+    ):
+        """Manager of database client relations."""
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.database = database_name
+        self.extra_user_roles = extra_user_roles
+        self.local_app = self.charm.model.app
+        self.local_unit = self.charm.unit
+        self.relation_name = relation_name
+        self.relations_aliases = relations_aliases
+        self.framework.observe(
+            self.charm.on[relation_name].relation_joined, self._on_relation_joined_event
+        )
+        self.framework.observe(
+            self.charm.on[relation_name].relation_changed, self._on_relation_changed_event
+        )
+
+        # Define custom event names for each alias.
+        if relations_aliases:
+            # Ensure the number of aliases does not exceed the maximum
+            # of connections allowed in the specific relation.
+            relation_connection_limit = self.charm.meta.requires[relation_name].limit
+            if len(relations_aliases) != relation_connection_limit:
+                raise ValueError(
+                    f"The number of aliases must match the maximum number of connections allowed in the relation. "
+                    f"Expected {relation_connection_limit}, got {len(relations_aliases)}"
+                )
+
+            for relation_alias in relations_aliases:
+                self.on.define_event(f"{relation_alias}_database_created", DatabaseCreatedEvent)
+                self.on.define_event(
+                    f"{relation_alias}_endpoints_changed", DatabaseEndpointsChangedEvent
+                )
+                self.on.define_event(
+                    f"{relation_alias}_read_only_endpoints_changed",
+                    DatabaseReadOnlyEndpointsChangedEvent,
+                )
+
+    def _assign_relation_alias(self, relation_id: int) -> None:
+        """Assigns an alias to a relation.
+
+        This function writes in the unit data bag.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+        """
+        # If no aliases were provided, return immediately.
+        if not self.relations_aliases:
+            return
+
+        # Return if an alias was already assigned to this relation
+        # (like when there are more than one unit joining the relation).
+        if (
+            self.charm.model.get_relation(self.relation_name, relation_id)
+            .data[self.local_unit]
+            .get("alias")
+        ):
+            return
+
+        # Retrieve the available aliases (the ones that weren't assigned to any relation).
+        available_aliases = self.relations_aliases[:]
+        for relation in self.charm.model.relations[self.relation_name]:
+            alias = relation.data[self.local_unit].get("alias")
+            if alias:
+                logger.debug("Alias %s was already assigned to relation %d", alias, relation.id)
+                available_aliases.remove(alias)
+
+        # Set the alias in the unit relation databag of the specific relation.
+        relation = self.charm.model.get_relation(self.relation_name, relation_id)
+        relation.data[self.local_unit].update({"alias": available_aliases[0]})
+
+    def _diff(self, event: RelationChangedEvent) -> Diff:
+        """Retrieves the diff of the data in the relation changed databag.
+
+        Args:
+            event: relation changed event.
+
+        Returns:
+            a Diff instance containing the added, deleted and changed
+                keys from the event relation databag.
+        """
+        # Retrieve the old data from the data key in the local unit relation databag.
+        old_data = json.loads(event.relation.data[self.local_unit].get("data", "{}"))
+        # Retrieve the new data from the event relation databag.
+        new_data = {
+            key: value for key, value in event.relation.data[event.app].items() if key != "data"
+        }
+
+        # These are the keys that were added to the databag and triggered this event.
+        added = new_data.keys() - old_data.keys()
+        # These are the keys that were removed from the databag and triggered this event.
+        deleted = old_data.keys() - new_data.keys()
+        # These are the keys that already existed in the databag,
+        # but had their values changed.
+        changed = {
+            key for key in old_data.keys() & new_data.keys() if old_data[key] != new_data[key]
+        }
+
+        # TODO: evaluate the possibility of losing the diff if some error
+        # happens in the charm before the diff is completely checked (DPE-412).
+        # Convert the new_data to a serializable format and save it for a next diff check.
+        event.relation.data[self.local_unit].update({"data": json.dumps(new_data)})
+
+        # Return the diff with all possible changes.
+        return Diff(added, changed, deleted)
+
+    def _emit_aliased_event(self, event: RelationChangedEvent, event_name: str) -> None:
+        """Emit an aliased event to a particular relation if it has an alias.
+
+        Args:
+            event: the relation changed event that was received.
+            event_name: the name of the event to emit.
+        """
+        alias = self._get_relation_alias(event.relation.id)
+        if alias:
+            getattr(self.on, f"{alias}_{event_name}").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+    def _get_relation_alias(self, relation_id: int) -> Optional[str]:
+        """Returns the relation alias.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+
+        Returns:
+            the relation alias or None if the relation was not found.
+        """
+        for relation in self.charm.model.relations[self.relation_name]:
+            if relation.id == relation_id:
+                return relation.data[self.local_unit].get("alias")
+        return None
+
+    def fetch_relation_data(self) -> dict:
+        """Retrieves data from relation.
+
+        This function can be used to retrieve data from a relation
+        in the charm code when outside an event callback.
+
+        Returns:
+            a dict of the values stored in the relation data bag
+                for all relation instances (indexed by the relation ID).
+        """
+        data = {}
+        for relation in self.relations:
+            data[relation.id] = {
+                key: value for key, value in relation.data[relation.app].items() if key != "data"
+            }
+        return data
+
+    def _update_relation_data(self, relation_id: int, data: dict) -> None:
+        """Updates a set of key-value pairs in the relation.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            data: dict containing the key-value pairs
+                that should be updated in the relation.
+        """
+        if self.local_unit.is_leader():
+            relation = self.charm.model.get_relation(self.relation_name, relation_id)
+            relation.data[self.local_app].update(data)
+
+    def _on_relation_joined_event(self, event: RelationJoinedEvent) -> None:
+        """Event emitted when the application joins the database relation."""
+        # If relations aliases were provided, assign one to the relation.
+        self._assign_relation_alias(event.relation.id)
+
+        # Sets both database and extra user roles in the relation
+        # if the roles are provided. Otherwise, sets only the database.
+        if self.extra_user_roles:
+            self._update_relation_data(
+                event.relation.id,
+                {
+                    "database": self.database,
+                    "extra-user-roles": self.extra_user_roles,
+                },
+            )
+        else:
+            self._update_relation_data(event.relation.id, {"database": self.database})
+
+    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
+        """Event emitted when the database relation has changed."""
+        # Check which data has changed to emit customs events.
+        diff = self._diff(event)
+
+        # Check if the database is created
+        # (the database charm shared the credentials).
+        if "username" in diff.added and "password" in diff.added:
+            # Emit the default event (the one without an alias).
+            logger.info("database created at %s", datetime.now())
+            self.on.database_created.emit(event.relation, app=event.app, unit=event.unit)
+
+            # Emit the aliased event (if any).
+            self._emit_aliased_event(event, "database_created")
+
+            # To avoid unnecessary application restarts do not trigger
+            # “endpoints_changed“ event if “database_created“ is triggered.
+            return
+
+        # Emit an endpoints changed event if the database
+        # added or changed this info in the relation databag.
+        if "endpoints" in diff.added or "endpoints" in diff.changed:
+            # Emit the default event (the one without an alias).
+            logger.info("endpoints changed on %s", datetime.now())
+            self.on.endpoints_changed.emit(event.relation, app=event.app, unit=event.unit)
+
+            # Emit the aliased event (if any).
+            self._emit_aliased_event(event, "endpoints_changed")
+
+            # To avoid unnecessary application restarts do not trigger
+            # “read_only_endpoints_changed“ event if “endpoints_changed“ is triggered.
+            return
+
+        # Emit a read only endpoints changed event if the database
+        # added or changed this info in the relation databag.
+        if "read-only-endpoints" in diff.added or "read-only-endpoints" in diff.changed:
+            # Emit the default event (the one without an alias).
+            logger.info("read-only-endpoints changed on %s", datetime.now())
+            self.on.read_only_endpoints_changed.emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+            # Emit the aliased event (if any).
+            self._emit_aliased_event(event, "read_only_endpoints_changed")
+
+    @property
+    def relations(self) -> List[Relation]:
+        """The list of Relation instances associated with this relation_name."""
+        return list(self.charm.model.relations[self.relation_name])

--- a/lib/charms/nginx_ingress_integrator/v0/nginx_route.py
+++ b/lib/charms/nginx_ingress_integrator/v0/nginx_route.py
@@ -13,6 +13,7 @@ Import `require_nginx_route` in your charm, with four required keyword arguments
 
 Other optional arguments include:
 - additional_hostnames
+- backend_protocol
 - limit_rps
 - limit_whitelist
 - max_body_size
@@ -68,7 +69,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 __all__ = ["require_nginx_route", "provide_nginx_route"]
 
@@ -159,6 +160,7 @@ def require_nginx_route(  # pylint: disable=too-many-locals,too-many-branches
     service_name: str,
     service_port: int,
     additional_hostnames: typing.Optional[str] = None,
+    backend_protocol: typing.Optional[str] = None,
     limit_rps: typing.Optional[int] = None,
     limit_whitelist: typing.Optional[str] = None,
     max_body_size: typing.Optional[int] = None,
@@ -187,6 +189,8 @@ def require_nginx_route(  # pylint: disable=too-many-locals,too-many-branches
             option via relation.
         additional_hostnames: configure Nginx ingress integrator
             additional-hostnames option via relation, optional.
+        backend_protocol: configure Nginx ingress integrator
+            backend-protocol option via relation, optional.
         limit_rps: configure Nginx ingress integrator limit-rps
             option via relation, optional.
         limit_whitelist: configure Nginx ingress integrator
@@ -225,6 +229,8 @@ def require_nginx_route(  # pylint: disable=too-many-locals,too-many-branches
         config["service-port"] = service_port
     if additional_hostnames is not None:
         config["additional-hostnames"] = additional_hostnames
+    if backend_protocol is not None:
+        config["backend-protocol"] = backend_protocol
     if limit_rps is not None:
         config["limit-rps"] = limit_rps
     if limit_whitelist is not None:

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -370,7 +370,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 35
+LIBPATCH = 36
 
 logger = logging.getLogger(__name__)
 
@@ -715,13 +715,12 @@ def _type_convert_stored(obj):
     """Convert Stored* to their appropriate types, recursively."""
     if isinstance(obj, StoredList):
         return list(map(_type_convert_stored, obj))
-    elif isinstance(obj, StoredDict):
+    if isinstance(obj, StoredDict):
         rdict = {}  # type: Dict[Any, Any]
         for k in obj.keys():
             rdict[k] = _type_convert_stored(obj[k])
         return rdict
-    else:
-        return obj
+    return obj
 
 
 def _validate_relation_by_interface_and_direction(
@@ -1440,7 +1439,7 @@ def _dedupe_job_names(jobs: List[dict]):
                 job["job_name"] = "{}_{}".format(job["job_name"], hashed)
     new_jobs = []
     for key in jobs_dict:
-        new_jobs.extend([i for i in jobs_dict[key]])
+        new_jobs.extend(list(jobs_dict[key]))
 
     # Deduplicate jobs which are equal
     # Again this in O(n^2) but it should be okay
@@ -1796,8 +1795,7 @@ class MetricsEndpointProvider(Object):
         jobs = self._jobs if self._jobs else [DEFAULT_JOB]
         if callable(self._lookaside_jobs):
             return jobs + PrometheusConfig.sanitize_scrape_configs(self._lookaside_jobs())
-        else:
-            return jobs
+        return jobs
 
     @property
     def _scrape_metadata(self) -> dict:
@@ -2078,6 +2076,7 @@ class MetricsEndpointAggregator(Object):
         Args:
             targets: a `dict` containing target information
             app_name: a `str` identifying the application
+            kwargs: a `dict` of the extra arguments passed to the function
         """
         if not self._charm.unit.is_leader():
             return
@@ -2203,6 +2202,7 @@ class MetricsEndpointAggregator(Object):
                 "port".
             application_name: a string name of the application for
                 which this static scrape job is being constructed.
+            kwargs: a `dict` of the extra arguments passed to the function
 
         Returns:
             A dictionary corresponding to a Prometheus static scrape

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 # For a complete list of supported options, see:
@@ -12,6 +12,7 @@ description: |
   the successful execution of services and applications (using workflows).
 maintainers: 
   - Commercial Systems <jaas-crew@lists.canonical.com>
+source: https://github.com/canonical/temporal-k8s-operator
 docs: https://discourse.charmhub.io/t/temporal-server-documentation-overview/8948
 tags:
   - temporal

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -33,10 +33,10 @@ requires:
     interface: temporal
     limit: 1
   db:
-    interface: pgsql
+    interface: postgresql_client
     limit: 1
   visibility:
-    interface: pgsql
+    interface: postgresql_client
     limit: 1
   nginx-route:
     interface: nginx-route

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 [tool.bandit]

--- a/src/charm.py
+++ b/src/charm.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 #
 # Learn more at: https://juju.is/docs/sdk

--- a/src/log.py
+++ b/src/log.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Define logging helpers."""

--- a/src/relations.py
+++ b/src/relations.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Define the Temporal server relations."""

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,18 +4,13 @@
 """Temporal charm integration test config."""
 
 import logging
-from pathlib import Path
 
 import pytest
 import pytest_asyncio
-import yaml
+from helpers import APP_NAME, APP_NAME_ADMIN, METADATA
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
-
-METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
-APP_NAME = METADATA["name"]
-APP_NAME_ADMIN = "temporal-admin-k8s"
 
 
 @pytest.mark.skip_if_deployed

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python3
-# Copyright 2023 Canonical Ltd Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Temporal charm integration test config."""

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd Ltd.
+# See LICENSE file for licensing details.
+
+"""Temporal charm integration test config."""
+
+import logging
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+import yaml
+from pytest_operator.plugin import OpsTest
+
+logger = logging.getLogger(__name__)
+
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+APP_NAME = METADATA["name"]
+APP_NAME_ADMIN = "temporal-admin-k8s"
+
+
+@pytest.mark.skip_if_deployed
+@pytest_asyncio.fixture(name="deploy", scope="module")
+async def deploy(ops_test: OpsTest):
+    """The app is up and running."""
+    charm = await ops_test.build_charm(".")
+    resources = {"temporal-server-image": METADATA["containers"]["temporal"]["upstream-source"]}
+
+    # Deploy temporal server, temporal admin and postgresql charms.
+    await ops_test.model.deploy(charm, resources=resources, application_name=APP_NAME, num_units=1)
+    await ops_test.model.deploy(APP_NAME_ADMIN, channel="edge")
+    await ops_test.model.deploy("postgresql-k8s", channel="14", trust=True)
+
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(
+            apps=[APP_NAME, APP_NAME_ADMIN], status="blocked", raise_on_blocked=False, timeout=600
+        )
+        await ops_test.model.wait_for_idle(
+            apps=["postgresql-k8s"], status="active", raise_on_blocked=False, timeout=600
+        )
+
+        assert ops_test.model.applications[APP_NAME].units[0].workload_status == "blocked"
+        await ops_test.model.integrate(f"{APP_NAME}:db", "postgresql-k8s:database")
+        await ops_test.model.integrate(f"{APP_NAME}:visibility", "postgresql-k8s:database")
+        await ops_test.model.integrate(f"{APP_NAME}:admin", f"{APP_NAME_ADMIN}:admin")
+        await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", raise_on_blocked=False, timeout=180)
+
+        # Register default namespace from admin charm.
+        action = (
+            await ops_test.model.applications[APP_NAME_ADMIN]
+            .units[0]
+            .run_action("tctl", args="--ns default namespace register -rd 3")
+        )
+        result = (await action.wait()).results
+        logger.info(f"tctl result: {result}")
+        assert "result" in result and result["result"] == "command succeeded"
+
+        await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", raise_on_blocked=False, timeout=300)
+        assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python3
-# Copyright 2023 Canonical Ltd Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Temporal charm integration test helpers."""

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd Ltd.
+# See LICENSE file for licensing details.
+
+"""Temporal charm integration test helpers."""
+
+import logging
+from multiprocessing import Process
+from pathlib import Path
+
+import yaml
+from pytest_operator.plugin import OpsTest
+from temporal_client.run_worker import sync_run_worker
+from temporal_client.trigger_workflow import trigger_workflow
+
+logger = logging.getLogger(__name__)
+
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+APP_NAME = METADATA["name"]
+APP_NAME_ADMIN = "temporal-admin-k8s"
+
+
+async def run_sample_workflow(ops_test: OpsTest):
+    """Connects a client and runs a basic Temporal workflow.
+
+    Args:
+        ops_test: PyTest object.
+    """
+    status = await ops_test.model.get_status()  # noqa: F821
+    address = status["applications"][APP_NAME].public_address
+    url = f"{address}:7233"
+    logger.info("running workflow on app address: %s", url)
+
+    p = Process(target=sync_run_worker, args=[url])
+    p.start()
+    logger.info("temporal worker running")
+    name = "Jean-luc"
+    result = await trigger_workflow(url, name)
+    p.terminate()
+
+    assert result == f"Hello, {name}!"

--- a/tests/integration/temporal_client/activities.py
+++ b/tests/integration/temporal_client/activities.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python3
-# Copyright 2023 Canonical Ltd Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 

--- a/tests/integration/temporal_client/run_worker.py
+++ b/tests/integration/temporal_client/run_worker.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python3
-# Copyright 2023 Canonical Ltd Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 

--- a/tests/integration/temporal_client/trigger_workflow.py
+++ b/tests/integration/temporal_client/trigger_workflow.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python3
-# Copyright 2023 Canonical Ltd Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Temporal client workflow runner."""

--- a/tests/integration/temporal_client/workflows.py
+++ b/tests/integration/temporal_client/workflows.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python3
-# Copyright 2023 Canonical Ltd Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2022 Canonical Ltd Ltd.
+# Copyright 2023 Canonical Ltd Ltd.
 # See LICENSE file for licensing details.
 
 """Temporal charm integration tests."""

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -5,60 +5,13 @@
 """Temporal charm integration tests."""
 
 import logging
-from multiprocessing import Process
-from pathlib import Path
 
 import pytest
-import pytest_asyncio
-import yaml
+from conftest import deploy  # noqa: F401, pylint: disable=W0611
+from helpers import run_sample_workflow
 from pytest_operator.plugin import OpsTest
-from temporal_client.run_worker import sync_run_worker
-from temporal_client.trigger_workflow import trigger_workflow
 
 logger = logging.getLogger(__name__)
-
-METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
-APP_NAME = METADATA["name"]
-APP_NAME_ADMIN = "temporal-admin-k8s"
-
-
-@pytest_asyncio.fixture(name="deploy", scope="module")
-async def deploy(ops_test: OpsTest):
-    """The app is up and running."""
-    charm = await ops_test.build_charm(".")
-    resources = {"temporal-server-image": METADATA["containers"]["temporal"]["upstream-source"]}
-
-    # Deploy temporal server, temporal admin and postgresql charms.
-    await ops_test.model.deploy(charm, resources=resources, application_name=APP_NAME)
-    await ops_test.model.deploy(APP_NAME_ADMIN, channel="edge")
-    await ops_test.model.deploy("postgresql-k8s", channel="edge", trust=True)
-
-    async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(
-            apps=[APP_NAME, APP_NAME_ADMIN], status="blocked", raise_on_blocked=False, timeout=600
-        )
-        await ops_test.model.wait_for_idle(
-            apps=["postgresql-k8s"], status="active", raise_on_blocked=False, timeout=600
-        )
-
-        assert ops_test.model.applications[APP_NAME].units[0].workload_status == "blocked"
-        await ops_test.model.integrate(f"{APP_NAME}:db", "postgresql-k8s:db")
-        await ops_test.model.integrate(f"{APP_NAME}:visibility", "postgresql-k8s:db")
-        await ops_test.model.integrate(f"{APP_NAME}:admin", f"{APP_NAME_ADMIN}:admin")
-        await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", raise_on_blocked=False, timeout=600)
-
-        # Register default namespace from admin charm.
-        action = (
-            await ops_test.model.applications[APP_NAME_ADMIN]
-            .units[0]
-            .run_action("tctl", args="--ns default namespace register -rd 3")
-        )
-        result = (await action.wait()).results
-        logger.info(f"tctl result: {result}")
-        assert "result" in result and result["result"] == "command succeeded"
-
-        await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", raise_on_blocked=False, timeout=600)
-        assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
 
 
 @pytest.mark.abort_on_fail
@@ -68,16 +21,4 @@ class TestDeployment:
 
     async def test_basic_client(self, ops_test: OpsTest):
         """Connects a client and runs a basic Temporal workflow."""
-        status = await ops_test.model.get_status()  # noqa: F821
-        address = status["applications"][APP_NAME]["units"][f"{APP_NAME}/0"]["address"]
-        url = f"{address}:7233"
-        logger.info("running workflow on app address: %s", url)
-
-        p = Process(target=sync_run_worker, args=[url])
-        p.start()
-        logger.info("temporal worker running")
-        name = "Jean-luc"
-        result = await trigger_workflow(url, name)
-        p.terminate()
-
-        assert result == f"Hello, {name}!"
+        await run_sample_workflow(ops_test)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python3
-# Copyright 2023 Canonical Ltd Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Temporal charm integration tests."""

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 #
 # Learn more about testing at: https://juju.is/docs/sdk/testing

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -92,8 +92,8 @@ class TestCharm(TestCase):
         harness.charm.on.temporal_pebble_ready.emit(container)
 
         # Simulate db readiness.
-        event = make_master_changed_event("db")
-        harness.charm._on_master_changed(event)
+        event = make_database_changed_event("db")
+        harness.charm._on_database_changed(event)
 
         # No plans are set yet.
         got_plan = harness.get_container_pebble_plan("temporal").to_dict()
@@ -117,12 +117,12 @@ class TestCharm(TestCase):
         harness.charm.on.temporal_pebble_ready.emit(container)
 
         # Simulate db readiness.
-        event = make_master_changed_event("db")
-        harness.charm._on_master_changed(event)
+        event = make_database_changed_event("db")
+        harness.charm._on_database_changed(event)
 
         # Simulate visibility readiness.
-        event = make_master_changed_event("visibility")
-        harness.charm._on_master_changed(event)
+        event = make_database_changed_event("visibility")
+        harness.charm._on_database_changed(event)
 
         # No plans are set yet.
         got_plan = harness.get_container_pebble_plan("temporal").to_dict()
@@ -148,12 +148,12 @@ class TestCharm(TestCase):
                     "environment": {
                         "DB_HOST": "myhost",
                         "DB_NAME": "temporal-k8s_db",
-                        "DB_PORT": "4247",
+                        "DB_PORT": "5432",
                         "DB_PSWD": "inner-light",
                         "DB_USER": "jean-luc@db",
                         "VISIBILITY_HOST": "myhost",
                         "VISIBILITY_NAME": "temporal-k8s_visibility",
-                        "VISIBILITY_PORT": "4247",
+                        "VISIBILITY_PORT": "5432",
                         "VISIBILITY_PSWD": "inner-light",
                         "VISIBILITY_USER": "jean-luc@visibility",
                         "LOG_LEVEL": "info",
@@ -190,12 +190,12 @@ class TestCharm(TestCase):
                     "environment": {
                         "DB_HOST": "myhost",
                         "DB_NAME": "temporal-k8s_db",
-                        "DB_PORT": "4247",
+                        "DB_PORT": "5432",
                         "DB_PSWD": "inner-light",
                         "DB_USER": "jean-luc@db",
                         "VISIBILITY_HOST": "myhost",
                         "VISIBILITY_NAME": "temporal-k8s_visibility",
-                        "VISIBILITY_PORT": "4247",
+                        "VISIBILITY_PORT": "5432",
                         "VISIBILITY_PSWD": "inner-light",
                         "VISIBILITY_USER": "jean-luc@visibility",
                         "LOG_LEVEL": "debug",
@@ -243,14 +243,14 @@ class TestCharm(TestCase):
                     "dbname": "temporal-k8s_db",
                     "host": "myhost",
                     "password": "inner-light",
-                    "port": "4247",
+                    "port": "5432",
                     "user": "jean-luc@db",
                 },
                 "visibility": {
                     "dbname": "temporal-k8s_visibility",
                     "host": "myhost",
                     "password": "inner-light",
-                    "port": "4247",
+                    "port": "5432",
                     "user": "jean-luc@visibility",
                 },
             },
@@ -273,10 +273,11 @@ class TestCharm(TestCase):
             "service-hostname": harness.charm.app.name,
             "service-name": harness.charm.app.name,
             "service-port": SERVER_PORT,
+            "backend-protocol": "GRPC",
             "tls-secret-name": "temporal-tls",
         }
 
-        new_hostname = "new-temporal-ui-k8s"
+        new_hostname = "new-temporal-k8s"
         harness.update_config({"external-hostname": new_hostname})
         harness.charm._require_nginx_route()
 
@@ -285,6 +286,7 @@ class TestCharm(TestCase):
             "service-hostname": new_hostname,
             "service-name": harness.charm.app.name,
             "service-port": SERVER_PORT,
+            "backend-protocol": "GRPC",
             "tls-secret-name": "temporal-tls",
         }
 
@@ -297,6 +299,7 @@ class TestCharm(TestCase):
             "service-hostname": new_hostname,
             "service-name": harness.charm.app.name,
             "service-port": SERVER_PORT,
+            "backend-protocol": "GRPC",
             "tls-secret-name": new_tls,
         }
 
@@ -315,12 +318,12 @@ def simulate_lifecycle(harness):
     harness.charm.on.temporal_pebble_ready.emit(container)
 
     # Simulate db readiness.
-    event = make_master_changed_event("db")
-    harness.charm._on_master_changed(event)
+    event = make_database_changed_event("db")
+    harness.charm._on_database_changed(event)
 
     # Simulate visibility readiness.
-    event = make_master_changed_event("visibility")
-    harness.charm._on_master_changed(event)
+    event = make_database_changed_event("visibility")
+    harness.charm._on_database_changed(event)
 
     # Simulate schema readiness.
     app = type("App", (), {"name": "temporal-k8s"})()
@@ -330,13 +333,13 @@ def simulate_lifecycle(harness):
     harness.charm.admin._on_admin_relation_changed(event)
 
 
-def make_master_changed_event(rel_name):
+def make_database_changed_event(rel_name):
     """Create and return a mock master changed event.
 
-    The event is generated by the relation with the given name.
+        The event is generated by the relation with the given name.
 
     Args:
-        rel_name: Relationship name.
+        rel_name: Name of the database relation (db or visibility)
 
     Returns:
         Event dict.
@@ -345,14 +348,9 @@ def make_master_changed_event(rel_name):
         "Event",
         (),
         {
-            "database": f"temporal-k8s_{rel_name}",
-            "master": {
-                "dbname": f"temporal-k8s_{rel_name}",
-                "host": "myhost",
-                "port": "4247",
-                "user": f"jean-luc@{rel_name}",
-                "password": "inner-light",
-            },
+            "endpoints": "myhost:5432,anotherhost:2345",
+            "username": f"jean-luc@{rel_name}",
+            "password": "inner-light",
             "relation": type("Relation", (), {"name": rel_name}),
         },
     )

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 [tox]


### PR DESCRIPTION
- With the new [postgresql-k8s charm stable](https://discourse.canonical.com/t/juju-operators-for-postgresql-and-mysql-are-now-stable/1786) release, it is recommended that charms using the legacy “pgsql” interface should migrate to the modern “postgresql_client” interface. This PR addresses this by updating the pgsql interface to postgresql_client and modifying all related observers and tests.
- Added the "backend_protocol" annotation to the nginx ingress resource to specify the GRPC backend protocol.