### PR TITLE
Refactor relations and fix "publish to edge" workflow

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -2,6 +2,7 @@ name: Integration tests
 
 on:
   pull_request:
+  workflow_call:
 
 jobs:
   integration-test-microk8s:

--- a/.github/workflows/test_and_publish_charm.yaml
+++ b/.github/workflows/test_and_publish_charm.yaml
@@ -14,7 +14,11 @@ on:
       - track/**
 
 jobs:
+  integration-tests:
+    uses: ./.github/workflows/integration_test.yaml
+    secrets: inherit
   publish-to-edge:
+    needs: [integration-tests]
     uses: canonical/operator-workflows/.github/workflows/test_and_publish_charm.yaml@main
     secrets: inherit
     with:
@@ -22,3 +26,4 @@ jobs:
       integration-test-provider: microk8s
       integration-test-provider-channel: 1.25-strict/stable
       integration-test-juju-channel: 3.1/stable
+      integration-test-modules: '["test_charm"]'

--- a/src/literals.py
+++ b/src/literals.py
@@ -1,0 +1,32 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+#
+# Learn more at: https://juju.is/docs/sdk
+
+"""Literals used by the Temporal K8s charm."""
+
+VALID_LOG_LEVELS = ["info", "debug", "warning", "error", "critical"]
+LOG_FILE = "/var/log/temporal"
+DB_NAME = "temporal-k8s_db"
+VISIBILITY_DB_NAME = "temporal-k8s_visibility"
+
+SERVICE_PORTS = {
+    "frontend": {
+        "grpc": 7233,
+        "http": 6933,
+    },
+    "matching": {
+        "grpc": 7235,
+        "http": 6935,
+    },
+    "history": {
+        "grpc": 7234,
+        "http": 6934,
+    },
+    "worker": {
+        "grpc": 7239,
+        "http": 6939,
+    },
+}
+
+PROMETHEUS_PORT = 9090

--- a/src/relations/__init__.py
+++ b/src/relations/__init__.py
@@ -1,5 +1,3 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
-
-
 """Unit tests config."""

--- a/src/relations/__init__.py
+++ b/src/relations/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+
+"""Unit tests config."""

--- a/src/relations/postgresql.py
+++ b/src/relations/postgresql.py
@@ -28,7 +28,6 @@ class Postgresql(framework.Object):
 
         # Handle db:pgsql and visibility:pgsql relations. The "db" and
         # "visibility" strings in this code block reflect the relation names.
-        # charm.db = DatabaseRequires(charm, relation_name=relation_name, database_name=db_name)
         charm.framework.observe(charm.db.on.database_created, self._on_database_changed)
         charm.framework.observe(charm.db.on.endpoints_changed, self._on_database_changed)
         charm.framework.observe(charm.on.db_relation_broken, self._on_database_relation_broken)

--- a/src/relations/postgresql.py
+++ b/src/relations/postgresql.py
@@ -47,10 +47,12 @@ class Postgresql(framework.Object):
             event.defer()
             return
 
-        if self.charm.unit.is_leader():
-            self.charm.unit.status = WaitingStatus(f"handling {event.relation.name} change")
-            self.charm._update_db_connections(event)
-            self.charm._update(event)
+        if not self.charm.unit.is_leader():
+            return
+
+        self.charm.unit.status = WaitingStatus(f"handling {event.relation.name} change")
+        self.charm._update_db_connections(event)
+        self.charm._update(event)
 
     @log_event_handler(logger)
     def _on_database_relation_broken(self, event: DatabaseEvent) -> None:

--- a/src/relations/postgresql.py
+++ b/src/relations/postgresql.py
@@ -1,0 +1,69 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Define the Temporal server postgresql relation."""
+
+import logging
+
+from charms.data_platform_libs.v0.database_requires import DatabaseEvent
+from ops import framework
+from ops.model import WaitingStatus
+
+from log import log_event_handler
+
+logger = logging.getLogger(__name__)
+
+
+class Postgresql(framework.Object):
+    """Client for temporal:postgresql relations."""
+
+    def __init__(self, charm):
+        """Construct.
+
+        Args:
+            charm: The charm to attach the hooks to.
+        """
+        super().__init__(charm, "db")
+        self.charm = charm
+
+        # Handle db:pgsql and visibility:pgsql relations. The "db" and
+        # "visibility" strings in this code block reflect the relation names.
+        # charm.db = DatabaseRequires(charm, relation_name=relation_name, database_name=db_name)
+        charm.framework.observe(charm.db.on.database_created, self._on_database_changed)
+        charm.framework.observe(charm.db.on.endpoints_changed, self._on_database_changed)
+        charm.framework.observe(charm.on.db_relation_broken, self._on_database_relation_broken)
+
+        charm.framework.observe(charm.visibility.on.database_created, self._on_database_changed)
+        charm.framework.observe(charm.visibility.on.endpoints_changed, self._on_database_changed)
+        charm.framework.observe(charm.on.visibility_relation_broken, self._on_database_relation_broken)
+
+    @log_event_handler(logger)
+    def _on_database_changed(self, event: DatabaseEvent) -> None:
+        """Handle database creation/change events.
+
+        Args:
+            event: The event triggered when the relation changed.
+        """
+        if not self.charm._state.is_ready():
+            event.defer()
+            return
+
+        if self.charm.unit.is_leader():
+            self.charm.unit.status = WaitingStatus(f"handling {event.relation.name} change")
+            self.charm._update_db_connections(event)
+            self.charm._update(event)
+
+    @log_event_handler(logger)
+    def _on_database_relation_broken(self, event: DatabaseEvent) -> None:
+        """Handle broken relations with the database.
+
+        Args:
+            event: The event triggered when the relation changed.
+        """
+        if not self.charm._state.is_ready():
+            event.defer()
+            return
+
+        if self.charm.unit.is_leader():
+            self.charm._state.database_connections[event.relation.name] = None
+            self.charm._update(event)

--- a/src/relations/ui.py
+++ b/src/relations/ui.py
@@ -1,0 +1,53 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Define the Temporal server ui relation."""
+
+import logging
+
+from ops import framework
+from ops.model import ActiveStatus
+
+from log import log_event_handler
+
+logger = logging.getLogger(__name__)
+
+
+class UI(framework.Object):
+    """Client for ui:temporal relations."""
+
+    def __init__(self, charm):
+        """Construct.
+
+        Args:
+            charm: The charm to attach the hooks to.
+        """
+        super().__init__(charm, "ui")
+        self.charm = charm
+        charm.framework.observe(charm.on.ui_relation_joined, self._on_ui_relation_joined)
+        charm.framework.observe(charm.on.ui_relation_changed, self._on_ui_relation_joined)
+
+    @log_event_handler(logger)
+    def _on_ui_relation_joined(self, event):
+        """Handle new ui:temporal relations.
+
+        Attempt to provide server status to the ui unit.
+
+        Args:
+            event: The event triggered when the relation changed.
+        """
+        if self.charm.unit.is_leader():
+            self._provide_server_status()
+
+    def _provide_server_status(self):
+        """Provide server status to the UI charm."""
+        charm = self.charm
+        server_status = charm.model.unit.status == ActiveStatus()
+
+        ui_relations = charm.model.relations["ui"]
+        if not ui_relations:
+            logger.debug("ui:temporal: not providing server status: ui not ready")
+            return
+        for relation in ui_relations:
+            logger.debug(f"ui:temporal: providing server status on relation {relation.id}")
+            relation.data[charm.app].update({"server_status": "ready" if server_status else "blocked"})

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -7,7 +7,13 @@ import logging
 
 import pytest
 import pytest_asyncio
-from helpers import APP_NAME, APP_NAME_ADMIN, METADATA, create_default_namespace
+from helpers import (
+    APP_NAME,
+    APP_NAME_ADMIN,
+    APP_NAME_UI,
+    METADATA,
+    create_default_namespace,
+)
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
@@ -23,11 +29,12 @@ async def deploy(ops_test: OpsTest):
     # Deploy temporal server, temporal admin and postgresql charms.
     await ops_test.model.deploy(charm, resources=resources, application_name=APP_NAME, num_units=1)
     await ops_test.model.deploy(APP_NAME_ADMIN, channel="edge")
+    await ops_test.model.deploy(APP_NAME_UI, channel="edge")
     await ops_test.model.deploy("postgresql-k8s", channel="14", trust=True)
 
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(
-            apps=[APP_NAME, APP_NAME_ADMIN], status="blocked", raise_on_blocked=False, timeout=600
+            apps=[APP_NAME, APP_NAME_ADMIN, APP_NAME_UI], status="blocked", raise_on_blocked=False, timeout=600
         )
         await ops_test.model.wait_for_idle(
             apps=["postgresql-k8s"], status="active", raise_on_blocked=False, timeout=600
@@ -38,8 +45,13 @@ async def deploy(ops_test: OpsTest):
         await ops_test.model.integrate(f"{APP_NAME}:visibility", "postgresql-k8s:database")
         await ops_test.model.integrate(f"{APP_NAME}:admin", f"{APP_NAME_ADMIN}:admin")
         await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", raise_on_blocked=False, timeout=180)
+        await ops_test.model.integrate(f"{APP_NAME}:ui", f"{APP_NAME_UI}:ui")
+        await ops_test.model.wait_for_idle(
+            apps=[APP_NAME, APP_NAME_UI], status="active", raise_on_blocked=False, timeout=180
+        )
 
         await create_default_namespace(ops_test)
 
         await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", raise_on_blocked=False, timeout=300)
         assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
+        assert ops_test.model.applications[APP_NAME_UI].units[0].workload_status == "active"

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
 APP_NAME_ADMIN = "temporal-admin-k8s"
+APP_NAME_UI = "temporal-ui-k8s"
 
 
 async def scale(ops_test: OpsTest, app, units):

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -7,8 +7,9 @@
 import logging
 
 import pytest
+import requests
 from conftest import deploy  # noqa: F401, pylint: disable=W0611
-from helpers import run_sample_workflow
+from helpers import APP_NAME_UI, run_sample_workflow
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
@@ -18,6 +19,16 @@ logger = logging.getLogger(__name__)
 @pytest.mark.usefixtures("deploy")
 class TestDeployment:
     """Integration tests for Temporal charm."""
+
+    async def test_ui_relation(self, ops_test: OpsTest):
+        """Perform GET request on the Temporal UI host."""
+        status = await ops_test.model.get_status()  # noqa: F821
+        address = status["applications"][APP_NAME_UI]["units"][f"{APP_NAME_UI}/0"]["address"]
+        url = f"http://{address}:8080"
+        logger.info("curling app address: %s", url)
+
+        response = requests.get(url, timeout=300)
+        assert response.status_code == 200
 
     async def test_basic_client(self, ops_test: OpsTest):
         """Connects a client and runs a basic Temporal workflow."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -94,7 +94,7 @@ class TestCharm(TestCase):
 
         # Simulate db readiness.
         event = make_database_changed_event("db")
-        harness.charm._on_database_changed(event)
+        harness.charm.postgres_actions._on_database_changed(event)
 
         # No plans are set yet.
         got_plan = harness.get_container_pebble_plan("temporal").to_dict()
@@ -119,11 +119,11 @@ class TestCharm(TestCase):
 
         # Simulate db readiness.
         event = make_database_changed_event("db")
-        harness.charm._on_database_changed(event)
+        harness.charm.postgres_actions._on_database_changed(event)
 
         # Simulate visibility readiness.
         event = make_database_changed_event("visibility")
-        harness.charm._on_database_changed(event)
+        harness.charm.postgres_actions._on_database_changed(event)
 
         # No plans are set yet.
         got_plan = harness.get_container_pebble_plan("temporal").to_dict()
@@ -328,11 +328,11 @@ def simulate_lifecycle(harness):
 
     # Simulate db readiness.
     event = make_database_changed_event("db")
-    harness.charm._on_database_changed(event)
+    harness.charm.postgres_actions._on_database_changed(event)
 
     # Simulate visibility readiness.
     event = make_database_changed_event("visibility")
-    harness.charm._on_database_changed(event)
+    harness.charm.postgres_actions._on_database_changed(event)
 
     # Simulate schema readiness.
     app = type("App", (), {"name": "temporal-k8s"})()

--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,7 @@ commands =
     isort --check-only --diff {[vars]src_path} {[vars]tst_path}
     black --check --diff {[vars]src_path} {[vars]tst_path}
     mypy {[vars]all_path} --ignore-missing-imports --follow-imports=skip --install-types --non-interactive
-    pylint {[vars]all_path} --disable=E0401,W1203,W0613,W0718,R0903,W1514,C0103,R0913,C0301,W0212,R0902,C0104,W0640
+    pylint {[vars]all_path} --disable=E0401,W1203,W0613,W0718,R0903,W1514,C0103,R0913,C0301,W0212,R0902,C0104,W0640,R0801
 
 [testenv:unit]
 description = Run tests


### PR DESCRIPTION
This PR aims to:
- Refactor the relations (admin, ui, postgresql) into separate files to make it easier to introduce new relations in the future.
- Fix the "publish to edge" workflow. With the introduction of the scaled deployment integration tests, there should be two separate integration tests run on two different models. However, the workflow runs them both on one model which causes issues. The change introduced runs the integration tests first, before running the "publish to edge" workflow and asking it to only run one of the integration test (test_charm).