### PR TITLE
CSS-3455: Add safe upgrades integration test

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -13,6 +13,7 @@ jobs:
         tox-environments:
           - integration-charm
           - integration-scaling
+          - integration-upgrades
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -111,7 +111,7 @@ async def get_unit_url(ops_test: OpsTest, application, unit, port, protocol="htt
         Unit URL of the form {protocol}://{address}:{port}
     """
     status = await ops_test.model.get_status()  # noqa: F821
-    address = status["applications"][application]["units"][f"{APP_NAME_UI}/{unit}"]["address"]
+    address = status["applications"][application]["units"][f"{application}/{unit}"]["address"]
     return f"{protocol}://{address}:{port}"
 
 

--- a/tests/integration/test_upgrades.py
+++ b/tests/integration/test_upgrades.py
@@ -1,0 +1,84 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Temporal charm upgrades integration tests."""
+
+import logging
+import time
+
+import pytest
+import pytest_asyncio
+import requests
+from helpers import (
+    APP_NAME,
+    APP_NAME_ADMIN,
+    APP_NAME_UI,
+    METADATA,
+    create_default_namespace,
+    get_unit_url,
+    perform_temporal_integrations,
+    run_sample_workflow,
+)
+from pytest_operator.plugin import OpsTest
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.skip_if_deployed
+@pytest_asyncio.fixture(name="deploy", scope="module")
+async def deploy(ops_test: OpsTest):
+    """The app is up and running."""
+    # Deploy temporal server, temporal admin and postgresql charms.
+    await ops_test.model.deploy(APP_NAME, channel="edge")
+    await ops_test.model.deploy(APP_NAME_ADMIN, channel="edge")
+    await ops_test.model.deploy(APP_NAME_UI, channel="edge")
+    await ops_test.model.deploy("postgresql-k8s", channel="14", trust=True)
+
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(
+            apps=[APP_NAME, APP_NAME_ADMIN, APP_NAME_UI], status="blocked", raise_on_blocked=False, timeout=600
+        )
+        await ops_test.model.wait_for_idle(
+            apps=["postgresql-k8s"], status="active", raise_on_blocked=False, timeout=600
+        )
+
+        await perform_temporal_integrations(ops_test)
+
+        await create_default_namespace(ops_test)
+
+        await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", raise_on_blocked=False, timeout=300)
+        assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
+        assert ops_test.model.applications[APP_NAME_UI].units[0].workload_status == "active"
+
+        await run_sample_workflow(ops_test)
+
+
+@pytest.mark.abort_on_fail
+@pytest.mark.usefixtures("deploy")
+class TestUpgrade:
+    """Integration test for Temporal charm upgrade from previous release."""
+
+    async def test_upgrade(self, ops_test: OpsTest):
+        """Builds the current charm and refreshes the current deployment."""
+        charm = await ops_test.build_charm(".")
+        resources = {"temporal-server-image": METADATA["containers"]["temporal"]["upstream-source"]}
+
+        await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", raise_on_blocked=False, timeout=600)
+
+        await ops_test.model.applications[APP_NAME].refresh(path=str(charm), resources=resources)
+
+        async with ops_test.fast_forward():
+            time.sleep(10)  # time for application to settle
+            await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", raise_on_blocked=False, timeout=600)
+            await ops_test.model.wait_for_idle(status="active")
+            assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
+
+            await run_sample_workflow(ops_test)
+
+    async def test_ui_relation(self, ops_test: OpsTest):
+        """Perform GET request on the Temporal UI host."""
+        url = await get_unit_url(ops_test, application=APP_NAME_UI, unit=0, port=8080)
+        logger.info("curling app address: %s", url)
+
+        response = requests.get(url, timeout=300)
+        assert response.status_code == 200

--- a/tox.ini
+++ b/tox.ini
@@ -125,3 +125,15 @@ deps =
     -r{toxinidir}/requirements.txt
 commands =
     pytest {[vars]tst_path}integration/test_scaling.py -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
+
+[testenv:integration-upgrades]
+description = Run integration tests
+deps =
+    ipdb==0.13.9
+    juju==3.1.0.1
+    pytest==7.1.3
+    pytest-operator==0.22.0
+    temporalio==1.1.0
+    -r{toxinidir}/requirements.txt
+commands =
+    pytest {[vars]tst_path}integration/test_upgrades.py -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}


### PR DESCRIPTION
This PR adds another integration test to check for the ability to safely upgrade to the newly released charm. The integration test deploys the charm from the latest channel available on Charmhub and upgrades it to the charm built from source. This ensures that the changes made in each PR are safe to upgrade to from the previous release.