### PR TITLE
CSS-3634: Modify charm with custom image

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ This charm is used to deploy Temporal server in a k8s cluster. For a local
 deployment, follow the following steps:
 
     # Install Microk8s from snap:
-    sudo snap install microk8s --classic --channel=1.24
+    sudo snap install microk8s --classic --channel=1.25
 
     # Install charmcraft from snap:
     sudo snap install charmcraft --classic
@@ -79,13 +79,13 @@ deployment, follow the following steps:
     charmcraft pack [--destructive-mode]
 
     # Deploy the charm:
-    juju deploy ./temporal-k8s_ubuntu-22.04-amd64.charm --resource temporal-server-image=temporalio/server:1.17.4
+    juju deploy ./temporal-k8s_ubuntu-22.04-amd64.charm --resource temporal-server-image=ghcr.io/canonical/temporal-server:latest
 
     # Deploy admin charm (Only if modifying admin charm, otherwise deploy as shown below):
-    juju deploy ./temporal-admin-k8s_ubuntu-22.04-amd64.charm --resource temporal-admin-image=temporalio/admin-tools:1.18.0
+    juju deploy ./temporal-admin-k8s_ubuntu-22.04-amd64.charm --resource temporal-admin-image=temporalio/admin-tools:1.21.5
 
     # Deploy ui charm (Only if modifying UI charm, otherwise deploy as shown below):
-    juju deploy ./temporal-ui-k8s_ubuntu-22.04-amd64.charm --resource temporal-ui-image=temporalio/ui:2.10.3
+    juju deploy ./temporal-ui-k8s_ubuntu-22.04-amd64.charm --resource temporal-ui-image=temporalio/ui:2.21.3
 
     # Relate operator to postgres:
     juju deploy postgresql-k8s --channel 14/stable --trust
@@ -187,3 +187,9 @@ Once done, the hostname will be set to the application name `temporal-ui-k8s` by
 default and can be changed through the `external-hostname` config. If the
 ingress relation has already been created through the previous step, then the
 web UI can be accessed by visiting `https://temporal-ui-k8s`.
+
+### openfga
+
+To enable authorization, the OpenFGA charm must be deployed. Instructions on how
+to enable authorization can be found
+[here](./documentation/how-to/authorization.md).

--- a/config.yaml
+++ b/config.yaml
@@ -3,7 +3,7 @@
 
 options:
   services:
-    default: frontend,history,matching,worker,internal-frontend
+    default: frontend,history,matching,worker
     description: |
       A comma-separated list of Temporal services to run. Temporal components
       can be either run in a single container or spread across multiple

--- a/config.yaml
+++ b/config.yaml
@@ -3,7 +3,7 @@
 
 options:
   services:
-    default: frontend,history,matching,worker
+    default: frontend,history,matching,worker,internal-frontend
     description: |
       A comma-separated list of Temporal services to run. Temporal components
       can be either run in a single container or spread across multiple

--- a/documentation/how-to/authorization.md
+++ b/documentation/how-to/authorization.md
@@ -1,7 +1,5 @@
 # Authorization
 
-> **Note:** (TODO) Functionality described on this page is not live yet.
-
 Enabling authorization requires that you have an active
 [Charmed Temporal K8s Operator](https://discourse.charmhub.io/t/charmed-temporal-k8s-tutorial-introduction/11777)
 deployed as described in the tutorial. It is recommended that you first go

--- a/documentation/how-to/scaling.md
+++ b/documentation/how-to/scaling.md
@@ -31,16 +31,15 @@ Note:
 - In a scaled deployment, only the unit deployed with the service `frontend`
   needs to be related to the `nginx-ingress-integrator` charm for ingress and
   the `openfga-k8s` charm for authorization.
-- The unit deployed with the service `frontend` should also handle the
+- The unit deployed with the service `frontend` will automatically handle the
   `internal-frontend` service, which is the internal gateway that the `worker`
   service uses to bypass authorization rules imposed for external connections.
-  This is only necessary when authorization is enabled.
 
 To deploy the services separately in a scalable way, you must deploy the
 application as follows:
 
 ```bash
-juju deploy temporal-k8s --config services="frontend,internal-frontend"
+juju deploy temporal-k8s --config services="frontend"
 juju deploy temporal-k8s --config services="matching" temporal-k8s-matching
 juju deploy temporal-k8s --config services="history" temporal-k8s-history
 juju deploy temporal-k8s --config services="worker" temporal-k8s-worker

--- a/documentation/how-to/scaling.md
+++ b/documentation/how-to/scaling.md
@@ -26,11 +26,21 @@ deployed as a separate application which can then be connected together by
 integrating with the same database. These services can then be scaled according
 to your needs.
 
+Note:
+
+- In a scaled deployment, only the unit deployed with the service `frontend`
+  needs to be related to the `nginx-ingress-integrator` charm for ingress and
+  the `openfga-k8s` charm for authorization.
+- The unit deployed with the service `frontend` should also handle the
+  `internal-frontend` service, which is the internal gateway that the `worker`
+  service uses to bypass authorization rules imposed for external connections.
+  This is only necessary when authorization is enabled.
+
 To deploy the services separately in a scalable way, you must deploy the
 application as follows:
 
 ```bash
-juju deploy temporal-k8s --config services="frontend"
+juju deploy temporal-k8s --config services="frontend,internal-frontend"
 juju deploy temporal-k8s --config services="matching" temporal-k8s-matching
 juju deploy temporal-k8s --config services="history" temporal-k8s-history
 juju deploy temporal-k8s --config services="worker" temporal-k8s-worker
@@ -113,7 +123,8 @@ output: |
         "10.1.232.42:6939",
         "10.1.232.61:6935",
         "10.1.232.6:6934",
-        "10.1.232.26:6933"
+        "10.1.232.26:6933",
+        "10.1.232.26:6936"
       ],
       "rings": [
         {
@@ -122,6 +133,15 @@ output: |
           "members": [
             {
               "identity": "10.1.232.26:7233"
+            }
+          ]
+        },
+        {
+          "role": "internal-frontend",
+          "memberCount": 1,
+          "members": [
+            {
+              "identity": "10.1.232.26:7236"
             }
           ]
         },
@@ -237,11 +257,13 @@ output: |
         "10.1.232.42:6939",
         "10.1.232.6:6934",
         "10.1.232.25:6933",
+        "10.1.232.25:6936",
         "10.1.232.51:6934",
         "10.1.232.23:6939",
         "10.1.232.38:6935",
         "10.1.232.61:6935",
-        "10.1.232.26:6933"
+        "10.1.232.26:6933",
+        "10.1.232.26:6936"
       ],
       "rings": [
         {
@@ -253,6 +275,18 @@ output: |
             },
             {
               "identity": "10.1.232.25:7233"
+            }
+          ]
+        },
+        {
+          "role": "internal-frontend",
+          "memberCount": 2,
+          "members": [
+            {
+              "identity": "10.1.232.26:7236"
+            },
+            {
+              "identity": "10.1.232.25:7236"
             }
           ]
         },

--- a/lib/charms/openfga_k8s/v0/openfga.py
+++ b/lib/charms/openfga_k8s/v0/openfga.py
@@ -98,7 +98,7 @@ class OpenFGAEvent(RelationEvent):
     @property
     def token_secret_id(self):
         return self.relation.data[self.relation.app].get("token_secret_id", "")
-    
+
     @property
     def token(self):
         return self.relation.data[self.relation.app].get("token", "")
@@ -142,9 +142,7 @@ class OpenFGARequires(Object):
     def __init__(self, charm, store_name: str):
         super().__init__(charm, RELATION_NAME)
 
-        self.framework.observe(
-            charm.on[RELATION_NAME].relation_joined, self._on_relation_joined
-        )
+        self.framework.observe(charm.on[RELATION_NAME].relation_joined, self._on_relation_joined)
         self.framework.observe(
             charm.on[RELATION_NAME].relation_changed,
             self._on_relation_changed,

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -64,7 +64,7 @@ containers:
   temporal:
     resource: temporal-server-image
     # Included for simplicity in integration tests.
-    upstream-source: temporalio/server:1.17.4
+    upstream-source: ghcr.io/canonical/temporal-server:latest
 
 resources:
   temporal-server-image:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ Jinja2==3.1.1
 ops==2.2.0
 cosl==0.0.6
 requests==2.31.0
-openfga-sdk==0.2.1
+openfga-sdk==0.3.1
+async-timeout==4.0.3

--- a/src/literals.py
+++ b/src/literals.py
@@ -28,6 +28,10 @@ SERVICE_PORTS = {
         "grpc": 7239,
         "http": 6939,
     },
+    "internal-frontend": {
+        "grpc": 7236,
+        "http": 6936,
+    },
 }
 
 PROMETHEUS_PORT = 9090

--- a/src/literals.py
+++ b/src/literals.py
@@ -5,6 +5,8 @@
 
 """Literals used by the Temporal K8s charm."""
 
+from enum import Enum
+
 VALID_LOG_LEVELS = ["info", "debug", "warning", "error", "critical"]
 LOG_FILE = "/var/log/temporal"
 DB_NAME = "temporal-k8s_db"
@@ -35,3 +37,19 @@ SERVICE_PORTS = {
 }
 
 PROMETHEUS_PORT = 9090
+
+
+class ValidServiceTypes(Enum):
+    """Enum of valid service types in Temporal.
+
+    Attributes:
+        FRONTEND: Represents the frontend service.
+        HISTORY: Represents the history service.
+        MATCHING: Represents the matching service.
+        WORKER: Represents the worker service.
+    """
+
+    FRONTEND = "frontend"
+    HISTORY = "history"
+    MATCHING = "matching"
+    WORKER = "worker"

--- a/src/relations/openfga.py
+++ b/src/relations/openfga.py
@@ -108,6 +108,10 @@ class OpenFGA(framework.Object):
         Args:
             event: The event triggered when the relation is created.
         """
+        if "frontend" not in self.charm.config["services"]:
+            logger.info(f"{event.relation.name} revoked, relation only supported for frontend service")
+            return
+
         if not event.store_id:
             logger.info(f"{event.relation.name} revoked, no store id")
             return

--- a/src/relations/ui.py
+++ b/src/relations/ui.py
@@ -42,7 +42,7 @@ class UI(framework.Object):
     def _provide_server_status(self):
         """Provide server status to the UI charm."""
         charm = self.charm
-        is_active = charm.model.unit.status == ActiveStatus()
+        is_active = charm.model.unit.status == ActiveStatus() or charm.model.unit.status == ActiveStatus("auth enabled")
 
         ui_relations = charm.model.relations["ui"]
         if not ui_relations:

--- a/templates/config.jinja
+++ b/templates/config.jinja
@@ -21,7 +21,7 @@ persistence:
     visibilityStore: visibility
     {%- set es = ENABLE_ES | default(False) %}
     {%- if es %}
-    advancedVisibilityStore: es-visibility
+    advancedVisibilityStore: visibility
     {%- endif %}
     datastores:
         default:
@@ -205,6 +205,12 @@ services:
             membershipPort: {{ WORKER_MEMBERSHIP_PORT | default("6939") }}
             bindOnIP: {{ BIND_ON_IP | default("0.0.0.0") }}
 
+    internal-frontend:
+        rpc:
+            grpcPort: {{ INTERNAL_FRONTEND_GRPC_PORT | default("7236") }}
+            membershipPort: {{ INTERNAL_FRONTEND_MEMBERSHIP_PORT | default("6936") }}
+            bindOnIP: {{ BIND_ON_IP | default("0.0.0.0") }}
+
 clusterMetadata:
     enableGlobalNamespace: false
     failoverVersionIncrement: 10
@@ -246,11 +252,6 @@ namespaceDefaults:
       state: "disabled"
       URI: "file:///tmp/temporal_vis_archival/development"
 
-{% set publicIp = BIND_ON_IP | default("127.0.0.1") -%}
-{%- set defaultPublicHostPost = publicIp + ":" + temporalGrpcPort %}
-publicClient:
-    hostPort: "{{ PUBLIC_FRONTEND_ADDRESS | default(defaultPublicHostPost) }}"
-
 dynamicConfigClient:
-    filepath: "{{ DYNAMIC_CONFIG_FILE_PATH | default("/etc/temporal/config/dynamicconfig/docker.yaml") }}"
+    filepath: "{{ DYNAMIC_CONFIG_FILE_PATH | default("/etc/temporal/config/dynamicconfig/development.yaml") }}"
     pollInterval: "60s"

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -106,7 +106,10 @@ class TestAuth:
 
         assert ops_test.model.applications[APP_NAME].status == "active"
 
-        await run_sample_workflow(ops_test)
+        try:
+            await run_sample_workflow(ops_test)
+        except RuntimeError as e:
+            assert "Request unauthorized." in str(e)
 
     async def test_openfga_add_auth_rule_action(self, ops_test: OpsTest):
         """Test add-auth-rule action."""

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -19,7 +19,7 @@ from helpers import (
 from pytest_operator.plugin import OpsTest
 
 ALL_SERVICES = ["temporal-k8s", "temporal-k8s-history", "temporal-k8s-matching", "temporal-k8s-worker"]
-ALL_CONFIG = ["frontend,internal-frontend", "history", "matching", "worker"]
+ALL_CONFIG = ["frontend", "history", "matching", "worker"]
 
 logger = logging.getLogger(__name__)
 

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -19,7 +19,7 @@ from helpers import (
 from pytest_operator.plugin import OpsTest
 
 ALL_SERVICES = ["temporal-k8s", "temporal-k8s-history", "temporal-k8s-matching", "temporal-k8s-worker"]
-ALL_CONFIG = ["frontend", "history", "matching", "worker"]
+ALL_CONFIG = ["frontend,internal-frontend", "history", "matching", "worker"]
 
 logger = logging.getLogger(__name__)
 
@@ -92,7 +92,6 @@ class TestScaling:
 
         await run_sample_workflow(ops_test)
 
-    @pytest.mark.skip  # skip until scaling down operations work in MicroK8s. Units currently go into "Terminated" state and scale remains at 2.
     async def test_scaling_down(self, ops_test: OpsTest):
         """Scale Temporal charm down to 1 unit."""
         for service in ALL_SERVICES:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -143,7 +143,7 @@ class TestCharm(TestCase):
                 "temporal": {
                     "summary": "temporal server",
                     "command": "temporal-server --env charm start "
-                    "--service=frontend --service=history --service=matching --service=worker",
+                    "--service=frontend --service=history --service=matching --service=worker --service=internal-frontend",
                     "startup": "enabled",
                     "override": "replace",
                     "environment": {
@@ -161,7 +161,6 @@ class TestCharm(TestCase):
                         "TEMPORAL_BROADCAST_ADDRESS": str(
                             self.harness.model.get_binding("peer").network.ingress_address
                         ),
-                        "PUBLIC_FRONTEND_ADDRESS": "temporal-k8s:7233",
                     },
                 }
             },
@@ -207,7 +206,6 @@ class TestCharm(TestCase):
                         "TEMPORAL_BROADCAST_ADDRESS": str(
                             self.harness.model.get_binding("peer").network.ingress_address
                         ),
-                        "PUBLIC_FRONTEND_ADDRESS": "temporal-k8s:7233",
                     },
                 }
             },
@@ -227,9 +225,7 @@ class TestCharm(TestCase):
         self.harness.update_config({"services": "worker,bad-wolf"})
 
         # The change is not applied to the plan.
-        want_command = (
-            "temporal-server --env charm start --service=frontend --service=history --service=matching --service=worker"
-        )
+        want_command = "temporal-server --env charm start --service=frontend --service=history --service=matching --service=worker --service=internal-frontend"
         got_command = harness.get_container_pebble_plan("temporal").to_dict()["services"]["temporal"]["command"]
         self.assertEqual(got_command, want_command)
 
@@ -360,7 +356,7 @@ class TestCharm(TestCase):
                 "temporal": {
                     "summary": "temporal server",
                     "command": "temporal-server --env charm start "
-                    "--service=frontend --service=history --service=matching --service=worker",
+                    "--service=frontend --service=history --service=matching --service=worker --service=internal-frontend",
                     "startup": "enabled",
                     "override": "replace",
                     "environment": {
@@ -382,7 +378,6 @@ class TestCharm(TestCase):
                         "TEMPORAL_BROADCAST_ADDRESS": str(
                             self.harness.model.get_binding("peer").network.ingress_address
                         ),
-                        "PUBLIC_FRONTEND_ADDRESS": "temporal-k8s:7233",
                         "OFGA_STORE_ID": harness.charm._state.openfga["store_id"],
                         "OFGA_AUTH_MODEL_ID": harness.charm._state.openfga["auth_model_id"],
                         "OFGA_API_HOST": harness.charm._state.openfga["address"],

--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,7 @@ commands =
     isort --check-only --diff {[vars]src_path} {[vars]tst_path}
     black --check --diff {[vars]src_path} {[vars]tst_path}
     mypy {[vars]all_path} --ignore-missing-imports --follow-imports=skip --install-types --non-interactive
-    pylint {[vars]all_path} --disable=E0401,W1203,W0613,W0718,R0903,W1514,C0103,R0913,C0301,W0212,R0902,C0104,W0640,R0801
+    pylint {[vars]all_path} --disable=E0401,W1203,W0613,W0718,R0903,W1514,C0103,R0913,C0301,W0212,R0902,C0104,W0640,R0801,W0511
 
 [testenv:unit]
 description = Run tests
@@ -100,7 +100,7 @@ deps =
     temporalio==1.1.0
     -r{toxinidir}/requirements.txt
 commands =
-   pytest {[vars]tst_path}integration -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
+   pytest {[vars]tst_path}integration -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} --destructive-mode
 
 [testenv:integration-charm]
 description = Run integration tests
@@ -110,9 +110,10 @@ deps =
     pytest==7.1.3
     pytest-operator==0.22.0
     temporalio==1.1.0
+    pytest-asyncio==0.21
     -r{toxinidir}/requirements.txt
 commands =
-    pytest {[vars]tst_path}integration/test_charm.py -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
+    pytest {[vars]tst_path}integration/test_charm.py -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} --destructive-mode
 
 [testenv:integration-scaling]
 description = Run integration tests
@@ -122,9 +123,10 @@ deps =
     pytest==7.1.3
     pytest-operator==0.22.0
     temporalio==1.1.0
+    pytest-asyncio==0.21
     -r{toxinidir}/requirements.txt
 commands =
-    pytest {[vars]tst_path}integration/test_scaling.py -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
+    pytest {[vars]tst_path}integration/test_scaling.py -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} --destructive-mode
 
 [testenv:integration-upgrades]
 description = Run integration tests
@@ -134,9 +136,10 @@ deps =
     pytest==7.1.3
     pytest-operator==0.22.0
     temporalio==1.1.0
+    pytest-asyncio==0.21
     -r{toxinidir}/requirements.txt
 commands =
-    pytest {[vars]tst_path}integration/test_upgrades.py -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
+    pytest {[vars]tst_path}integration/test_upgrades.py -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} --destructive-mode
 
 [testenv:integration-auth]
 description = Run integration tests
@@ -146,6 +149,7 @@ deps =
     pytest==7.1.3
     pytest-operator==0.22.0
     temporalio==1.1.0
+    pytest-asyncio==0.21
     -r{toxinidir}/requirements.txt
 commands =
-    pytest {[vars]tst_path}integration/test_auth.py -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
+    pytest {[vars]tst_path}integration/test_auth.py -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} --destructive-mode


### PR DESCRIPTION
This PR replaces the upstream image that has been used for the Temporal server charm thus far with the [custom image](https://github.com/canonical/charmed-temporal-image/pkgs/container/temporal-server) that was developed, which includes a custom authorizer using OpenFGA. The PR introduces the following:

- The addition of the `internal-frontend` service which is used by the server's `worker` service to bypass authorization rules.
- Modification of scaling instructions to include the `internal-frontend` service and how to include ingress and authorization with a scaled deployment.
- Modification of the `config.jinja` file to reflect the `internal-frontend` service as well as using the same database for [`visibility`](https://docs.temporal.io/visibility) and [`advanced visibility`](https://docs.temporal.io/visibility#advanced-visibility).