### PR TITLE
Update license headers and dependencies

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 restart:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 # Learn more about charmcraft.yaml configuration at:

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 options:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 # For a complete list of supported options, see:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 [tool.bandit]

--- a/src/charm.py
+++ b/src/charm.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 #
 # Learn more at: https://juju.is/docs/sdk

--- a/src/literals.py
+++ b/src/literals.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 #
 # Learn more at: https://juju.is/docs/sdk

--- a/src/log.py
+++ b/src/log.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Define logging helpers."""

--- a/src/relations/__init__.py
+++ b/src/relations/__init__.py
@@ -1,3 +1,3 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 """Unit tests config."""

--- a/src/relations/admin.py
+++ b/src/relations/admin.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Define the Temporal server admin relation."""

--- a/src/relations/openfga.py
+++ b/src/relations/openfga.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Define the Temporal server openfga relation."""

--- a/src/relations/postgresql.py
+++ b/src/relations/postgresql.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Define the Temporal server postgresql relation."""

--- a/src/relations/ui.py
+++ b/src/relations/ui.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Define the Temporal server ui relation."""

--- a/src/state.py
+++ b/src/state.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Manager for handling charm state."""

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Temporal charm integration test config."""
@@ -6,7 +6,6 @@
 import asyncio
 import logging
 
-import pytest
 import pytest_asyncio
 from helpers import (
     APP_NAME,
@@ -21,7 +20,6 @@ from pytest_operator.plugin import OpsTest
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.skip_if_deployed
 @pytest_asyncio.fixture(name="deploy", scope="module")
 async def deploy(ops_test: OpsTest):
     """The app is up and running."""

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Temporal charm integration test helpers."""

--- a/tests/integration/temporal_client/activities.py
+++ b/tests/integration/temporal_client/activities.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 

--- a/tests/integration/temporal_client/workflows.py
+++ b/tests/integration/temporal_client/workflows.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Temporal charm integration tests."""

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Temporal charm integration tests."""

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Temporal charm scaling integration tests."""

--- a/tests/integration/test_upgrades.py
+++ b/tests/integration/test_upgrades.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Temporal charm upgrades integration tests."""

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 #
 # Learn more about testing at: https://juju.is/docs/sdk/testing

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 [tox]
@@ -96,8 +96,9 @@ deps =
     ipdb==0.13.9
     juju==3.1.0.1
     pytest==7.1.3
-    pytest-operator==0.22.0
+    pytest-operator==0.31.1
     temporalio==1.1.0
+    pytest-asyncio==0.21
     -r{toxinidir}/requirements.txt
 commands =
    pytest {[vars]tst_path}integration -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} --destructive-mode
@@ -108,7 +109,7 @@ deps =
     ipdb==0.13.9
     juju==3.1.0.1
     pytest==7.1.3
-    pytest-operator==0.22.0
+    pytest-operator==0.31.1
     temporalio==1.1.0
     pytest-asyncio==0.21
     -r{toxinidir}/requirements.txt
@@ -121,7 +122,7 @@ deps =
     ipdb==0.13.9
     juju==3.1.0.1
     pytest==7.1.3
-    pytest-operator==0.22.0
+    pytest-operator==0.31.1
     temporalio==1.1.0
     pytest-asyncio==0.21
     -r{toxinidir}/requirements.txt
@@ -134,7 +135,7 @@ deps =
     ipdb==0.13.9
     juju==3.1.0.1
     pytest==7.1.3
-    pytest-operator==0.22.0
+    pytest-operator==0.31.1
     temporalio==1.1.0
     pytest-asyncio==0.21
     -r{toxinidir}/requirements.txt
@@ -147,7 +148,7 @@ deps =
     ipdb==0.13.9
     juju==3.1.0.1
     pytest==7.1.3
-    pytest-operator==0.22.0
+    pytest-operator==0.31.1
     temporalio==1.1.0
     pytest-asyncio==0.21
     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
Due to the most recent "[Publish to edge](https://github.com/canonical/temporal-k8s-operator/actions/runs/7127968459)" action run failing, this PR attempts to see if updating some dependencies would solve this.