### PR TITLE
Open internal frontend service port

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -292,6 +292,13 @@ class TemporalK8SCharm(CharmBase):
                 close_port(port=ports["grpc"])
                 close_port(port=ports["http"])
 
+        if "frontend" in services:
+            open_port(port=SERVICE_PORTS["internal-frontend"]["grpc"])
+            open_port(port=SERVICE_PORTS["internal-frontend"]["http"])
+        else:
+            close_port(port=SERVICE_PORTS["internal-frontend"]["grpc"])
+            close_port(port=SERVICE_PORTS["internal-frontend"]["http"])
+
     def _update(self, event):
         """Update the Temporal server configuration and replan its execution.
 


### PR DESCRIPTION
As the admin charm connects to the server on the frontend port `7233` to run `tctl` actions, enabling auth prevents the admin from connecting anymore due to the lack of authentication mechanisms in the admin charm. Given that the admin charm is deployed alongside the server, it does not have to be subject to auth rules and should be able to connect to the server directly. This can be achieved by exposing the service port `7236` of the `internal-frontend` service, which does not apply any auth rules, and having the admin charm connect to port `7236`.