### PR TITLE
Add pebble plan validation

### DIFF
--- a/documentation/tutorial/07-deploy-ingress.md
+++ b/documentation/tutorial/07-deploy-ingress.md
@@ -193,7 +193,22 @@ sudo nano /etc/hosts
 
 By default, the hostname will be set to the respective application names
 `temporal-k8s` and `temporal-ui-k8s`. You can then connect a Temporal client
-through this hostname i.e. `Client.connect("temporal-k8s")`.
+through this hostname as follows, where `[CERTIFICATE]` is the `.crt` file generated previously:
+
+```python
+from temporalio.client import Client, TLSConfig
+
+tls_root_cas = """
+-----BEGIN CERTIFICATE-----
+[CERTIFICATE]
+-----END CERTIFICATE-----
+"""
+
+enc_tls_root_cas = tls_root_cas.encode()
+tls = TLSConfig(server_root_ca_cert=enc_tls_root_cas, domain="temporal-k8s")
+
+client = await Client.connect("temporal-k8s", tls=tls)
+```
 
 > **See next:
 > [Deploy Temporal Worker](/t/charmed-temporal-k8s-tutorial-deploy-temporal-worker/11784)**

--- a/src/charm.py
+++ b/src/charm.py
@@ -253,10 +253,11 @@ class TemporalK8SCharm(CharmBase):
             self._update(event)
             return
 
-        check = container.get_check("up")
-        if check.status != CheckStatus.UP:
-            self.unit.status = MaintenanceStatus("Status check: DOWN")
-            return
+        if "frontend" in self.config["services"]:
+            check = container.get_check("up")
+            if check.status != CheckStatus.UP:
+                self.unit.status = MaintenanceStatus("Status check: DOWN")
+                return
 
         self.set_active_unit_status()
         if self.unit.is_leader():

--- a/src/charm.py
+++ b/src/charm.py
@@ -17,7 +17,7 @@ from charms.nginx_ingress_integrator.v0.nginx_route import require_nginx_route
 from charms.openfga_k8s.v0.openfga import OpenFGARequires
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
 from jinja2 import Environment, FileSystemLoader
-from ops import main
+from ops import main, pebble
 from ops.charm import CharmBase
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 from ops.pebble import CheckStatus
@@ -271,8 +271,11 @@ class TemporalK8SCharm(CharmBase):
         Returns:
             bool of pebble plan validity
         """
-        plan = container.get_plan().to_dict()
-        return bool(plan and plan["services"].get(self.name, {}).get("on-check-failure"))
+        try:
+            plan = container.get_plan().to_dict()
+            return bool(plan and plan["services"].get(self.name, {}).get("on-check-failure"))
+        except pebble.ConnectionError:
+            return False
 
     def _check_missing_openfga_params(self):
         """Validate that all OpenFGA required properties were extracted.

--- a/src/charm.py
+++ b/src/charm.py
@@ -253,11 +253,10 @@ class TemporalK8SCharm(CharmBase):
             self._update(event)
             return
 
-        if "frontend" in self.config["services"]:
-            check = container.get_check("up")
-            if check.status != CheckStatus.UP:
-                self.unit.status = MaintenanceStatus("Status check: DOWN")
-                return
+        check = container.get_check("up")
+        if check.status != CheckStatus.UP:
+            self.unit.status = MaintenanceStatus("Status check: DOWN")
+            return
 
         self.set_active_unit_status()
         if self.unit.is_leader():
@@ -443,7 +442,7 @@ class TemporalK8SCharm(CharmBase):
                     "level": "alive",
                     "period": "300s",
                     # curl cluster health of internal-frontend service
-                    "exec": {"command": "tctl --address=0.0.0.0:7236 cluster health"},
+                    "exec": {"command": "tctl --address=temporal-k8s:7236 cluster health"},
                 }
             },
         }

--- a/src/charm.py
+++ b/src/charm.py
@@ -273,8 +273,8 @@ class TemporalK8SCharm(CharmBase):
         """
         try:
             plan = container.get_plan().to_dict()
-            return bool(plan and plan["services"].get(self.name, {}).get("on-check-failure"))
-        except pebble.ConnectionError:
+            return bool(plan["services"][self.name]["on-check-failure"])
+        except (KeyError, pebble.ConnectionError):
             return False
 
     def _check_missing_openfga_params(self):

--- a/src/charm.py
+++ b/src/charm.py
@@ -91,7 +91,7 @@ class TemporalK8SCharm(CharmBase):
         self.framework.observe(self.on.config_changed, self._on_config_changed)
         self.framework.observe(self.on.restart_action, self._on_restart_action)
         self.framework.observe(self.on.peer_relation_changed, self._on_peer_relation_changed)
-        # self.framework.observe(self.on.update_status, self._on_update_status)
+        self.framework.observe(self.on.update_status, self._on_update_status)
 
         # Handle postgresql relation.
         self.db = DatabaseRequires(self, relation_name="db", database_name=DB_NAME, extra_user_roles="admin")
@@ -266,7 +266,7 @@ class TemporalK8SCharm(CharmBase):
             bool of pebble plan validity
         """
         plan = container.get_plan().to_dict()
-        return bool(plan)
+        return bool(plan and plan["services"].get(self.name, {}).get("on-check-failure"))
 
     def _check_missing_openfga_params(self):
         """Validate that all OpenFGA required properties were extracted.
@@ -428,16 +428,23 @@ class TemporalK8SCharm(CharmBase):
                     # Including config values here so that a change in the
                     # config forces replanning to restart the service.
                     "environment": context,
+                    "on-check-failure": {"up": "ignore"},
+                }
+            },
+            "checks": {
+                "up": {
+                    "override": "replace",
+                    "level": "alive",
+                    "period": "300s",
+                    # curl cluster health of internal-frontend service
+                    "exec": {"command": "tctl --address=temporal-k8s:7236 cluster health"},
                 }
             },
         }
         container.add_layer(self.name, pebble_layer, combine=True)
         container.replan()
 
-        # self.unit.status = MaintenanceStatus("replanning application")
-        self.set_active_unit_status()
-        if self.unit.is_leader():
-            self.ui._provide_server_status()
+        self.unit.status = MaintenanceStatus("replanning application")
 
 
 if __name__ == "__main__":

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -32,16 +32,15 @@ async def scale(ops_test: OpsTest, app, units):
     """
     await ops_test.model.applications[app].scale(scale=units)
 
-    async with ops_test.fast_forward():
-        # Wait for model to settle
-        await ops_test.model.wait_for_idle(
-            apps=[app],
-            status="active",
-            idle_period=30,
-            raise_on_blocked=True,
-            timeout=600,
-            wait_for_exact_units=units,
-        )
+    # Wait for model to settle
+    await ops_test.model.wait_for_idle(
+        apps=[app],
+        status="active",
+        idle_period=30,
+        raise_on_blocked=True,
+        timeout=300,
+        wait_for_exact_units=units,
+    )
 
     assert len(ops_test.model.applications[app].units) == units
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -32,15 +32,16 @@ async def scale(ops_test: OpsTest, app, units):
     """
     await ops_test.model.applications[app].scale(scale=units)
 
-    # Wait for model to settle
-    await ops_test.model.wait_for_idle(
-        apps=[app],
-        status="active",
-        idle_period=30,
-        raise_on_blocked=True,
-        timeout=300,
-        wait_for_exact_units=units,
-    )
+    async with ops_test.fast_forward():
+        # Wait for model to settle
+        await ops_test.model.wait_for_idle(
+            apps=[app],
+            status="active",
+            idle_period=30,
+            raise_on_blocked=True,
+            timeout=600,
+            wait_for_exact_units=units,
+        )
 
     assert len(ops_test.model.applications[app].units) == units
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -38,7 +38,7 @@ async def scale(ops_test: OpsTest, app, units):
         status="active",
         idle_period=30,
         raise_on_blocked=True,
-        timeout=300,
+        timeout=600,
         wait_for_exact_units=units,
     )
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -122,7 +122,7 @@ async def simulate_charm_crash(ops_test: OpsTest):
     Args:
         ops_test: PyTest object.
     """
-    await ops_test.model.applications[APP_NAME].destroy(force=True)
+    await ops_test.model.applications[APP_NAME].destroy()
     await ops_test.model.block_until(lambda: APP_NAME not in ops_test.model.applications)
 
     charm = await ops_test.build_charm(".")

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -32,84 +32,86 @@ class TestAuth:
     async def test_openfga_relation(self, ops_test: OpsTest):
         """Add OpenFGA relation and authorization model."""
         await ops_test.model.applications[APP_NAME].set_config({"auth-enabled": "true"})
-        await ops_test.model.deploy("openfga-k8s", channel="latest/edge")
-        await ops_test.model.wait_for_idle(
-            apps=[APP_NAME, "openfga-k8s"],
-            status="blocked",
-            raise_on_blocked=False,
-            timeout=1200,
-        )
+        await ops_test.model.deploy("openfga-k8s", channel="1.0/edge")
 
-        logger.info("adding openfga postgresql relation")
-        await ops_test.model.integrate("openfga-k8s:database", "postgresql-k8s:database")
+        async with ops_test.fast_forward():
+            await ops_test.model.wait_for_idle(
+                apps=[APP_NAME, "openfga-k8s"],
+                status="blocked",
+                raise_on_blocked=False,
+                timeout=1200,
+            )
 
-        await ops_test.model.wait_for_idle(
-            apps=["openfga-k8s"],
-            status="blocked",
-            raise_on_blocked=False,
-            timeout=1200,
-        )
+            logger.info("adding openfga postgresql relation")
+            await ops_test.model.integrate("openfga-k8s:database", "postgresql-k8s:database")
 
-        openfga_unit = ops_test.model.applications["openfga-k8s"].units[0]
-        for i in range(10):
-            action: Action = await openfga_unit.run_action("schema-upgrade")
-            result = await action.wait()
-            logger.info(f"attempt {i} -> action result {result.status} {result.results}")
-            if result.results == {"result": "done", "return-code": 0}:
-                break
-            time.sleep(2)
+            await ops_test.model.wait_for_idle(
+                apps=["openfga-k8s"],
+                status="blocked",
+                raise_on_blocked=False,
+                timeout=1200,
+            )
 
-        await ops_test.model.wait_for_idle(
-            apps=["openfga-k8s"],
-            status="active",
-            raise_on_blocked=False,
-            timeout=1200,
-        )
-
-        logger.info("adding openfga relation")
-        await ops_test.model.integrate(APP_NAME, "openfga-k8s")
-
-        await ops_test.model.wait_for_idle(
-            apps=[APP_NAME],
-            status="blocked",
-            raise_on_blocked=False,
-            timeout=600,
-        )
-
-        logger.info("running the create authorization model action")
-        temporal_unit = ops_test.model.applications[APP_NAME].units[0]
-        with open("./temporal_auth_model.json", "r", encoding="utf-8") as model_file:
-            model_data = model_file.read()
-
-            # Remove whitespace and newlines from JSON object
-            json_text = "".join(model_data.split())
-            data = json.loads(json_text)
-            model_data = json.dumps(data, separators=(",", ":"))
-
+            openfga_unit = ops_test.model.applications["openfga-k8s"].units[0]
             for i in range(10):
-                action = await temporal_unit.run_action(
-                    "create-authorization-model",
-                    model=model_data,
-                )
+                action: Action = await openfga_unit.run_action("schema-upgrade")
                 result = await action.wait()
                 logger.info(f"attempt {i} -> action result {result.status} {result.results}")
-                if result.status == "completed" and result.results == {"return-code": 0}:
+                if result.results == {"result": "done", "return-code": 0}:
                     break
                 time.sleep(2)
 
-        await ops_test.model.wait_for_idle(
-            apps=[APP_NAME],
-            status="active",
-            raise_on_blocked=True,
-            timeout=300,
-        )
+            await ops_test.model.wait_for_idle(
+                apps=["openfga-k8s"],
+                status="active",
+                raise_on_blocked=False,
+                timeout=1200,
+            )
 
-        assert ops_test.model.applications[APP_NAME].status == "active"
+            logger.info("adding openfga relation")
+            await ops_test.model.integrate(APP_NAME, "openfga-k8s")
 
-        try:
-            await run_sample_workflow(ops_test)
-        except RuntimeError as e:
-            assert "Request unauthorized." in str(e)
+            await ops_test.model.wait_for_idle(
+                apps=[APP_NAME],
+                status="blocked",
+                raise_on_blocked=False,
+                timeout=600,
+            )
+
+            logger.info("running the create authorization model action")
+            temporal_unit = ops_test.model.applications[APP_NAME].units[0]
+            with open("./temporal_auth_model.json", "r", encoding="utf-8") as model_file:
+                model_data = model_file.read()
+
+                # Remove whitespace and newlines from JSON object
+                json_text = "".join(model_data.split())
+                data = json.loads(json_text)
+                model_data = json.dumps(data, separators=(",", ":"))
+
+                for i in range(10):
+                    action = await temporal_unit.run_action(
+                        "create-authorization-model",
+                        model=model_data,
+                    )
+                    result = await action.wait()
+                    logger.info(f"attempt {i} -> action result {result.status} {result.results}")
+                    if result.status == "completed" and result.results == {"return-code": 0}:
+                        break
+                    time.sleep(2)
+
+            await ops_test.model.wait_for_idle(
+                apps=[APP_NAME],
+                status="active",
+                raise_on_blocked=True,
+                timeout=600,
+            )
+
+            assert ops_test.model.applications[APP_NAME].status == "active"
+
+            try:
+                await run_sample_workflow(ops_test)
+            except RuntimeError as e:
+                assert "Request unauthorized." in str(e)
 
     async def test_openfga_add_auth_rule_action(self, ops_test: OpsTest):
         """Test add-auth-rule action."""

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -31,6 +31,8 @@ async def deploy(ops_test: OpsTest):
     charm = await ops_test.build_charm(".")
     resources = {"temporal-server-image": METADATA["containers"]["temporal"]["upstream-source"]}
 
+    await ops_test.model.set_config({"update-status-hook-interval": "1m"})
+
     # Deploy temporal server, temporal admin and postgresql charms.
     for i in range(4):
         # for service in ALL_SERVICES:

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -40,14 +40,14 @@ async def deploy(ops_test: OpsTest):
 
     await ops_test.model.deploy(APP_NAME_ADMIN, channel="edge")
     await ops_test.model.deploy(APP_NAME_UI, channel="edge")
-    await ops_test.model.deploy("postgresql-k8s", channel="14", trust=True)
+    await ops_test.model.deploy("postgresql-k8s", channel="14/stable", trust=True)
 
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(
             apps=[APP_NAME_ADMIN, APP_NAME_UI] + ALL_SERVICES, status="blocked", raise_on_blocked=False, timeout=1200
         )
         await ops_test.model.wait_for_idle(
-            apps=["postgresql-k8s"], status="active", raise_on_blocked=False, timeout=600
+            apps=["postgresql-k8s"], status="active", raise_on_blocked=False, timeout=1200
         )
 
         for service in ALL_SERVICES:

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -57,7 +57,7 @@ async def deploy(ops_test: OpsTest):
         await ops_test.model.integrate(f"{APP_NAME}:db", "postgresql-k8s:database")
         await ops_test.model.integrate(f"{APP_NAME}:visibility", "postgresql-k8s:database")
         await ops_test.model.integrate(f"{APP_NAME}:admin", f"{APP_NAME_ADMIN}:admin")
-        await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", raise_on_blocked=False, timeout=180)
+        await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", raise_on_blocked=False, timeout=600)
 
         for service in ALL_SERVICES:
             if service != "temporal-k8s":
@@ -69,12 +69,12 @@ async def deploy(ops_test: OpsTest):
 
         await ops_test.model.integrate(f"{APP_NAME}:ui", f"{APP_NAME_UI}:ui")
         await ops_test.model.wait_for_idle(
-            apps=[APP_NAME, APP_NAME_UI], status="active", raise_on_blocked=False, timeout=180
+            apps=[APP_NAME, APP_NAME_UI], status="active", raise_on_blocked=False, timeout=1200
         )
 
         await create_default_namespace(ops_test)
 
-        await ops_test.model.wait_for_idle(apps=ALL_SERVICES, status="active", raise_on_blocked=False, timeout=300)
+        await ops_test.model.wait_for_idle(apps=ALL_SERVICES, status="active", raise_on_blocked=False, timeout=1200)
         assert ops_test.model.applications["temporal-k8s"].units[0].workload_status == "active"
 
         await run_sample_workflow(ops_test)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -9,9 +9,9 @@
 # pylint:disable=protected-access
 
 import json
-from unittest import TestCase, mock
+from unittest import TestCase
 
-from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
+from ops.model import ActiveStatus, BlockedStatus
 from ops.testing import Harness
 
 from charm import TemporalK8SCharm

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -12,14 +12,12 @@ import json
 from unittest import TestCase, mock
 
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
-from ops.pebble import CheckStatus
 from ops.testing import Harness
 
 from charm import TemporalK8SCharm
 from state import State
 
 SERVER_PORT = "7233"
-mock_incomplete_pebble_plan = {"services": {"temporal": {"override": "replace"}}}
 
 
 class TestCharm(TestCase):
@@ -164,7 +162,6 @@ class TestCharm(TestCase):
                             self.harness.model.get_binding("peer").network.ingress_address
                         ),
                     },
-                    "on-check-failure": {"up": "ignore"},
                 },
             },
         }
@@ -176,7 +173,8 @@ class TestCharm(TestCase):
         self.assertTrue(service.is_running())
 
         # The ActiveStatus is set with no message.
-        self.assertEqual(harness.model.unit.status, MaintenanceStatus("replanning application"))
+        # self.assertEqual(harness.model.unit.status, MaintenanceStatus("replanning application"))
+        self.assertEqual(harness.model.unit.status, ActiveStatus())
 
     def test_config_changed(self):
         """The pebble plan changes according to config changes."""
@@ -210,14 +208,14 @@ class TestCharm(TestCase):
                             self.harness.model.get_binding("peer").network.ingress_address
                         ),
                     },
-                    "on-check-failure": {"up": "ignore"},
                 },
             },
         }
         got_plan = harness.get_container_pebble_plan("temporal").to_dict()
         self.assertEqual(got_plan, want_plan)
 
-        self.assertEqual(harness.model.unit.status, MaintenanceStatus("replanning application"))
+        # self.assertEqual(harness.model.unit.status, MaintenanceStatus("replanning application"))
+        self.assertEqual(harness.model.unit.status, ActiveStatus())
 
     def test_invalid_config_value(self):
         """The charm blocks if an invalid config value is provided."""
@@ -388,84 +386,30 @@ class TestCharm(TestCase):
                         "OFGA_SECRETS_BEARER_TOKEN": harness.charm._state.openfga["token"],
                         "OFGA_API_PORT": harness.charm._state.openfga["port"],
                     },
-                    "on-check-failure": {"up": "ignore"},
                 }
             },
         }
         got_plan = harness.get_container_pebble_plan("temporal").to_dict()
         self.assertEqual(got_plan, want_plan)
 
-        # self.assertEqual(harness.model.unit.status, ActiveStatus("auth enabled"))
-        self.assertEqual(harness.model.unit.status, MaintenanceStatus("replanning application"))
-
-    def test_update_status_up(self):
-        """The charm updates the unit status to active based on UP status."""
-        harness = self.harness
-
-        simulate_lifecycle(harness)
-        harness.update_config({"auth-enabled": True})
-
-        secret_id = harness.add_model_secret("temporal-k8s", {"token": "openfga_token"})
-        event = make_openfga_store_created_event(secret_id)
-        harness.charm.openfga_relation._on_openfga_store_created(event)
-
-        harness.charm._state.openfga = {
-            **harness.charm._state.openfga,
-            "auth_model_id": "123",
-        }
-
-        harness.update_config({})
-
-        container = harness.model.unit.get_container("temporal")
-        container.get_check = mock.Mock(status="up")
-        container.get_check.return_value.status = CheckStatus.UP
-        harness.charm.on.update_status.emit()
-
+        # self.assertEqual(harness.model.unit.status, MaintenanceStatus("replanning application"))
+        # harness.charm.on.update_status.emit()
         self.assertEqual(harness.model.unit.status, ActiveStatus("auth enabled"))
 
-    def test_update_status_down(self):
-        """The charm updates the unit status to maintenance based on DOWN status."""
-        harness = self.harness
+    # @mock.patch("charm.TemporalK8SCharm._validate_pebble_plan", return_value=True)
+    # def test_missing_pebble_plan(self, mock_validate_pebble_plan):
+    #     """The charm re-applies the pebble plan if missing."""
+    #     harness = self.harness
+    #     simulate_lifecycle(harness)
 
-        simulate_lifecycle(harness)
-
-        container = harness.model.unit.get_container("temporal")
-        container.get_check = mock.Mock(status="up")
-        container.get_check.return_value.status = CheckStatus.DOWN
-        harness.charm.on.update_status.emit()
-
-        self.assertEqual(harness.model.unit.status, MaintenanceStatus("Status check: DOWN"))
-
-    def test_incomplete_pebble_plan(self):
-        """The charm re-applies the pebble plan if incomplete."""
-        harness = self.harness
-        simulate_lifecycle(harness)
-
-        container = harness.model.unit.get_container("temporal")
-        container.add_layer("temporal", mock_incomplete_pebble_plan, combine=True)
-        harness.charm.on.update_status.emit()
-
-        self.assertEqual(
-            harness.model.unit.status,
-            MaintenanceStatus("replanning application"),
-        )
-        plan = harness.get_container_pebble_plan("temporal").to_dict()
-        assert plan != mock_incomplete_pebble_plan
-
-    @mock.patch("charm.TemporalK8SCharm._validate_pebble_plan", return_value=True)
-    def test_missing_pebble_plan(self, mock_validate_pebble_plan):
-        """The charm re-applies the pebble plan if missing."""
-        harness = self.harness
-        simulate_lifecycle(harness)
-
-        mock_validate_pebble_plan.return_value = False
-        harness.charm.on.update_status.emit()
-        self.assertEqual(
-            harness.model.unit.status,
-            MaintenanceStatus("replanning application"),
-        )
-        plan = harness.get_container_pebble_plan("temporal").to_dict()
-        assert plan is not None
+    #     mock_validate_pebble_plan.return_value = False
+    #     harness.charm.on.update_status.emit()
+    #     self.assertEqual(
+    #         harness.model.unit.status,
+    #         MaintenanceStatus("replanning application"),
+    #     )
+    #     plan = harness.get_container_pebble_plan("temporal").to_dict()
+    #     assert plan is not None
 
 
 def simulate_lifecycle(harness):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -9,15 +9,17 @@
 # pylint:disable=protected-access
 
 import json
-from unittest import TestCase
+from unittest import TestCase, mock
 
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
+from ops.pebble import CheckStatus
 from ops.testing import Harness
 
 from charm import TemporalK8SCharm
 from state import State
 
 SERVER_PORT = "7233"
+mock_incomplete_pebble_plan = {"services": {"temporal": {"override": "replace"}}}
 
 
 class TestCharm(TestCase):
@@ -173,9 +175,7 @@ class TestCharm(TestCase):
         service = harness.model.unit.get_container("temporal").get_service("temporal")
         self.assertTrue(service.is_running())
 
-        # The ActiveStatus is set with no message.
         self.assertEqual(harness.model.unit.status, MaintenanceStatus("replanning application"))
-        # self.assertEqual(harness.model.unit.status, ActiveStatus())
 
     def test_config_changed(self):
         """The pebble plan changes according to config changes."""
@@ -217,7 +217,6 @@ class TestCharm(TestCase):
         self.assertEqual(got_plan, want_plan)
 
         self.assertEqual(harness.model.unit.status, MaintenanceStatus("replanning application"))
-        # self.assertEqual(harness.model.unit.status, ActiveStatus())
 
     def test_invalid_config_value(self):
         """The charm blocks if an invalid config value is provided."""
@@ -396,23 +395,80 @@ class TestCharm(TestCase):
         self.assertEqual(got_plan, want_plan)
 
         self.assertEqual(harness.model.unit.status, MaintenanceStatus("replanning application"))
+        container = harness.model.unit.get_container("temporal")
+        container.get_check = mock.Mock(status="up")
+        container.get_check.return_value.status = CheckStatus.UP
         harness.charm.on.update_status.emit()
         self.assertEqual(harness.model.unit.status, ActiveStatus("auth enabled"))
 
-    # @mock.patch("charm.TemporalK8SCharm._validate_pebble_plan", return_value=True)
-    # def test_missing_pebble_plan(self, mock_validate_pebble_plan):
-    #     """The charm re-applies the pebble plan if missing."""
-    #     harness = self.harness
-    #     simulate_lifecycle(harness)
+    def test_update_status_up(self):
+        """The charm updates the unit status to active based on UP status."""
+        harness = self.harness
 
-    #     mock_validate_pebble_plan.return_value = False
-    #     harness.charm.on.update_status.emit()
-    #     self.assertEqual(
-    #         harness.model.unit.status,
-    #         MaintenanceStatus("replanning application"),
-    #     )
-    #     plan = harness.get_container_pebble_plan("temporal").to_dict()
-    #     assert plan is not None
+        simulate_lifecycle(harness)
+        harness.update_config({"auth-enabled": True})
+
+        secret_id = harness.add_model_secret("temporal-k8s", {"token": "openfga_token"})
+        event = make_openfga_store_created_event(secret_id)
+        harness.charm.openfga_relation._on_openfga_store_created(event)
+
+        harness.charm._state.openfga = {
+            **harness.charm._state.openfga,
+            "auth_model_id": "123",
+        }
+
+        harness.update_config({})
+
+        container = harness.model.unit.get_container("temporal")
+        container.get_check = mock.Mock(status="up")
+        container.get_check.return_value.status = CheckStatus.UP
+        harness.charm.on.update_status.emit()
+
+        self.assertEqual(harness.model.unit.status, ActiveStatus("auth enabled"))
+
+    def test_update_status_down(self):
+        """The charm updates the unit status to maintenance based on DOWN status."""
+        harness = self.harness
+
+        simulate_lifecycle(harness)
+
+        container = harness.model.unit.get_container("temporal")
+        container.get_check = mock.Mock(status="up")
+        container.get_check.return_value.status = CheckStatus.DOWN
+        harness.charm.on.update_status.emit()
+
+        self.assertEqual(harness.model.unit.status, MaintenanceStatus("Status check: DOWN"))
+
+    def test_incomplete_pebble_plan(self):
+        """The charm re-applies the pebble plan if incomplete."""
+        harness = self.harness
+        simulate_lifecycle(harness)
+
+        container = harness.model.unit.get_container("temporal")
+        container.add_layer("temporal", mock_incomplete_pebble_plan, combine=True)
+        harness.charm.on.update_status.emit()
+
+        self.assertEqual(
+            harness.model.unit.status,
+            MaintenanceStatus("replanning application"),
+        )
+        plan = harness.get_container_pebble_plan("temporal").to_dict()
+        assert plan != mock_incomplete_pebble_plan
+
+    @mock.patch("charm.TemporalK8SCharm._validate_pebble_plan", return_value=True)
+    def test_missing_pebble_plan(self, mock_validate_pebble_plan):
+        """The charm re-applies the pebble plan if missing."""
+        harness = self.harness
+        simulate_lifecycle(harness)
+
+        mock_validate_pebble_plan.return_value = False
+        harness.charm.on.update_status.emit()
+        self.assertEqual(
+            harness.model.unit.status,
+            MaintenanceStatus("replanning application"),
+        )
+        plan = harness.get_container_pebble_plan("temporal").to_dict()
+        assert plan is not None
 
 
 def simulate_lifecycle(harness):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -11,7 +11,7 @@
 import json
 from unittest import TestCase
 
-from ops.model import ActiveStatus, BlockedStatus
+from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
 from ops.testing import Harness
 
 from charm import TemporalK8SCharm
@@ -162,6 +162,7 @@ class TestCharm(TestCase):
                             self.harness.model.get_binding("peer").network.ingress_address
                         ),
                     },
+                    "on-check-failure": {"up": "ignore"},
                 },
             },
         }
@@ -173,8 +174,8 @@ class TestCharm(TestCase):
         self.assertTrue(service.is_running())
 
         # The ActiveStatus is set with no message.
-        # self.assertEqual(harness.model.unit.status, MaintenanceStatus("replanning application"))
-        self.assertEqual(harness.model.unit.status, ActiveStatus())
+        self.assertEqual(harness.model.unit.status, MaintenanceStatus("replanning application"))
+        # self.assertEqual(harness.model.unit.status, ActiveStatus())
 
     def test_config_changed(self):
         """The pebble plan changes according to config changes."""
@@ -208,14 +209,15 @@ class TestCharm(TestCase):
                             self.harness.model.get_binding("peer").network.ingress_address
                         ),
                     },
+                    "on-check-failure": {"up": "ignore"},
                 },
             },
         }
         got_plan = harness.get_container_pebble_plan("temporal").to_dict()
         self.assertEqual(got_plan, want_plan)
 
-        # self.assertEqual(harness.model.unit.status, MaintenanceStatus("replanning application"))
-        self.assertEqual(harness.model.unit.status, ActiveStatus())
+        self.assertEqual(harness.model.unit.status, MaintenanceStatus("replanning application"))
+        # self.assertEqual(harness.model.unit.status, ActiveStatus())
 
     def test_invalid_config_value(self):
         """The charm blocks if an invalid config value is provided."""
@@ -386,14 +388,15 @@ class TestCharm(TestCase):
                         "OFGA_SECRETS_BEARER_TOKEN": harness.charm._state.openfga["token"],
                         "OFGA_API_PORT": harness.charm._state.openfga["port"],
                     },
+                    "on-check-failure": {"up": "ignore"},
                 }
             },
         }
         got_plan = harness.get_container_pebble_plan("temporal").to_dict()
         self.assertEqual(got_plan, want_plan)
 
-        # self.assertEqual(harness.model.unit.status, MaintenanceStatus("replanning application"))
-        # harness.charm.on.update_status.emit()
+        self.assertEqual(harness.model.unit.status, MaintenanceStatus("replanning application"))
+        harness.charm.on.update_status.emit()
         self.assertEqual(harness.model.unit.status, ActiveStatus("auth enabled"))
 
     # @mock.patch("charm.TemporalK8SCharm._validate_pebble_plan", return_value=True)


### PR DESCRIPTION
This PR does the following: 
- Adds a status check for the workload container which runs a tctl command to check cluster health before setting the charm's status to active.
- Adds a handler to reapply the pebble plan after a restart with the `pebble-ready` event to address this [bug](https://warthogs.atlassian.net/browse/CSS-6875) (See this [PR](https://github.com/canonical/superset-k8s-operator/pull/28) for reference).
- Slightly updates the tutorial instructions for enabling ingress.