### PR TITLE
Add upgrade server and documentation updates

### DIFF
--- a/documentation/how-to/authentication.md
+++ b/documentation/how-to/authentication.md
@@ -4,7 +4,7 @@ Clients of the Charmed Temporal k8s Operator can be authenticated in two
 different ways as described below. Authentication entails acquiring a Google
 OAuth access token, which will be attached to each request made to the Temporal
 Server on the `Authorization` header. The
-[Authorization](/t/charmed-temporal-k8s-how-to-authorization/12587) page will
+[Authorization](https://discourse.charmhub.io/t/charmed-temporal-k8s-how-to-authorization/12587) page will
 discuss further how this access token is further utilized on the Temporal
 Server.
 
@@ -92,6 +92,6 @@ clients, you can also use the
 [temporal-lib-py](https://github.com/canonical/temporal-lib-py) client libraries
 and injecting your service account credentials.
 
-The [Authorization](/t/charmed-temporal-k8s-how-to-authorization/12587) page
+The [Authorization](https://discourse.charmhub.io/t/charmed-temporal-k8s-how-to-authorization/12587) page
 discusses further how to authorize users and restrict their access to namespaces
 once they are authenticated.

--- a/documentation/how-to/authorization.md
+++ b/documentation/how-to/authorization.md
@@ -246,11 +246,11 @@ enabled as follows:
 
 ```bash
 
-# Configure admin group (can be multiple comma-separated groups)
+# Configure admin group (can be multiple comma-separated groups) and add system admin
 juju config temporal-k8s auth-admin-groups="admins"
+juju run temporal-k8s/0 add-auth-rule user="<your_email>" group="admins"
 
 # List system admins
-juju run temporal-k8s/0 add-auth-rule user="<your_email>" group="admins"
 juju run temporal-k8s/0 list-system-admins
 
 # Output:

--- a/documentation/how-to/authorization.md
+++ b/documentation/how-to/authorization.md
@@ -4,12 +4,12 @@ Enabling authorization requires that you have an active
 [Charmed Temporal K8s Operator](https://discourse.charmhub.io/t/charmed-temporal-k8s-tutorial-introduction/11777)
 deployed as described in the tutorial. It is recommended that you first go
 through the steps of enabling authentication as outlined
-[here](/t/charmed-temporal-k8s-how-to-authentication/12586).
+[here](https://discourse.charmhub.io/t/charmed-temporal-k8s-how-to-authentication/12586).
 
 By default the Temporal Server doesn't offer any authorization, but it offers
 the plugin mechanism to add a custom one. We have added an OAuth-based
-[authentication](/t/charmed-temporal-k8s-how-to-authentication/12586) using
-Google Cloud and an authorization mechanism that leverages
+[authentication](https://discourse.charmhub.io/t/charmed-temporal-k8s-how-to-authentication/12586)
+using Google Cloud and an authorization mechanism that leverages
 [Google Cloud](https://cloud.google.com) and [OpenFGA](https://openfga.dev/).
 This custom build of the Temporal Server can be found
 [here](https://github.com/canonical/charmed-temporal-image).
@@ -49,13 +49,6 @@ To relate the two charms together, run the following command:
 
 ```bash
 juju relate openfga-k8s postgresql-k8s
-```
-
-Once the `openfga-k8s` unit settles, you will see a message
-`Please run schema-upgrade action`. You must now run the following action:
-
-```bash
-juju run openfga-k8s/leader schema-upgrade --wait 30s
 ```
 
 Wait until the charm has settled - when ready, `juju status --relations` will
@@ -150,8 +143,8 @@ temporal-k8s:peer                 temporal-k8s:peer              temporal       
 
 At this point, our Temporal Server is active again with authorization enabled.
 This means that any request made to the Temporal Server will need to be
-[authenticted](/t/charmed-temporal-k8s-how-to-authentication/12586) using Google
-OAuth.
+[authenticated](https://discourse.charmhub.io/t/charmed-temporal-k8s-how-to-authentication/12586)
+using Google OAuth.
 
 ## Create OpenFGA Authorization Rules
 
@@ -219,14 +212,14 @@ The following actions may also be used for removing auth rules, checking access
 rules and for auditing purposes:
 
 ```bash
-# Check auth rule
+# 1. Check auth rule
 juju run temporal-k8s/0 check-auth-rule user="<your_email>" namespace="default" role="writer"
 
 # Output:
 output: "True"
 result: command succeeded
 
-# List auth rules
+# 2. List auth rules
 juju run temporal-k8s/0 list-auth-rule user="<your_email>"
 
 # Output:
@@ -237,10 +230,36 @@ output: |
   writer: '[''namespace:default'']'
 result: command succeeded
 
-# Remove auth rule
+# 3. Remove auth rule
 juju run temporal-k8s/0 remove-auth-rule user="<your_email>" group="test_group"
 
 # Output:
 output: 'operation type "delete" for user "<your_email>" on group "test_group" successful'
 result: command succeeded
 ```
+
+### Temporal System Admins
+
+A Temporal System Admin refers to anyone who has access to all namespaces, as
+well as the ability to administer namespace creation and removal. This can be
+enabled as follows:
+
+```bash
+
+# Configure admin group (can be multiple comma-separated groups)
+juju config temporal-k8s auth-admin-groups="admins"
+
+# List system admins
+juju run temporal-k8s/0 add-auth-rule user="<your_email>" group="admins"
+juju run temporal-k8s/0 list-system-admins
+
+# Output:
+output:
+  admins: '[''<your_email>'']'
+result: command succeeded
+
+```
+
+Once configured, the user with `<your_email>` will be able to see all namespaces
+through the Web UI as well as create new namespaces using
+[tctl](https://discourse.charmhub.io/t/charmed-temporal-k8s-how-to-tctl/11788).

--- a/documentation/how-to/tctl.md
+++ b/documentation/how-to/tctl.md
@@ -3,24 +3,36 @@
 [tctl](https://docs.temporal.io/tctl-v1) is a command-line tool that can be used
 to interact with a Temporal Cluster.
 
-The tool is available for use as an action in the Charmed Temporal Admin K8s
+The tool is available for use as follows:
+
+## Tctl Snap
+
+Tctl can be installed as a
+[snap](https://github.com/canonical/charmed-temporal-image/tree/main/tctl-snap)
+and used on your local machine. The tctl snap can be used on Temporal server
+environments with authorization enabled by enabling Google IAM login. More
+instructions can be found on the snap's documentation page.
+
+## Temporal Admin Charm
+
+Tctl commands can be run as an action in the Charmed Temporal Admin K8s
 operator. Once deployed and related to the Temporal server, we can run any of
 the available commands such as:
 
-## Create Namespace
+### Create Namespace
 
 ```bash
-juju run temporal-admin-k8s/0 tctl args="--ns default namespace register -rd 3"
+juju run temporal-admin-k8s/0 tctl args="--ns default namespace register -rd 3" --wait 1m
 ```
 
-## List Namespaces
+### List Namespaces
 
 ```bash
-juju run temporal-admin-k8s/0 tctl args="namespace list"
+juju run temporal-admin-k8s/0 tctl args="namespace list" --wait 1m
 ```
 
-## Start Workflow Execution
+### Start Workflow Execution
 
 ```bash
-juju run temporal-admin-k8s/0 tctl args='workflow start --taskqueue test-queue --workflow_type GreetingWorkflow --input '\"World\"''
+juju run temporal-admin-k8s/0 tctl args='workflow start --taskqueue test-queue --workflow_type GreetingWorkflow --input '\"World\"'' --wait 1m
 ```

--- a/documentation/how-to/upgrade-server.md
+++ b/documentation/how-to/upgrade-server.md
@@ -1,0 +1,45 @@
+# Upgrade Temporal Server
+
+Excerpt from
+[Temporal's documentation](https://docs.temporal.io/self-hosted-guide/upgrade-server):
+
+> Temporal Server should be upgraded sequentially. That is, if you're on version
+> (v1.n.x), your next upgrade should be to (v1.n+1.x) or the closest available
+> subsequent version. This sequence should be repeated until your desired
+> version is reached.
+>
+> 1. Upgrade Database Schema: Before initiating the Temporal Server upgrade, use
+>    one of the recommended upgrade tools to update your database schema. This
+>    ensures it is aligned with the version of Temporal Server you aim to
+>    upgrade to.
+> 2. Upgrade Temporal Server: Once the database schema is updated, proceed to
+>    upgrade the Temporal Server deployment to the next sequential version.
+>
+> Also, be aware that each upgrade requires the History Service to load all
+> Shards and update the Shard metadata, so allow approximately 10 minutes on
+> each version for these processes to complete before upgrading to the next
+> version.
+
+The Charmed Temporal K8s charms facilitate server upgrades in the following way:
+
+1. The Charmed Temporal Admin charm should be updated to the next revision that
+   you currently have deployed as follows:
+
+   ```bash
+   juju refresh temporal-admin-k8s --revision=<your_revision + 1>
+   ```
+
+   This will ensure that your database schema is updated if any updates are
+   available.
+
+2. The Charmed Temporal K8s charm should be updated to the next revision that
+   you currently have deployed as follows:
+
+   ```bash
+   juju refresh temporal-k8s --revision=<your_revision + 1>
+   ```
+
+_Warning: It is essential that upgrades are done one consecutive revision at a
+time. Charmed Temporal K8s can only guarantee backward compatibility between two
+consecutive revisions in line with the upgrade system adopted by the Temporal
+Server._

--- a/documentation/how-to/upgrade-server.md
+++ b/documentation/how-to/upgrade-server.md
@@ -20,10 +20,11 @@ Excerpt from
 > each version for these processes to complete before upgrading to the next
 > version.
 
-The Charmed Temporal K8s charms facilitate server upgrades in the following way:
+The Temporal K8s charms facilitate server upgrades in the following way:
 
-1. The Charmed Temporal Admin charm should be updated to the next revision that
-   you currently have deployed as follows:
+1. The Temporal Admin charm should be updated to the next
+   [charm revision](https://juju.is/docs/sdk/revision) that you currently have
+   deployed as follows:
 
    ```bash
    juju refresh temporal-admin-k8s --revision=<your_revision + 1>
@@ -32,8 +33,8 @@ The Charmed Temporal K8s charms facilitate server upgrades in the following way:
    This will ensure that your database schema is updated if any updates are
    available.
 
-2. The Charmed Temporal K8s charm should be updated to the next revision that
-   you currently have deployed as follows:
+2. The Temporal K8s charm should be updated to the next charm revision
+   that you currently have deployed as follows:
 
    ```bash
    juju refresh temporal-k8s --revision=<your_revision + 1>

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -20,37 +20,38 @@ manner for production purposes.
 
 ## In This Documentation
 
-|                                                                                                                                                                        |                                                                                                                                        |
-| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| [Tutorial](/t/charmed-temporal-k8s-tutorial-introduction/11777) </br> Get started - a hands-on introduction to using Charmed Temporal K8s operator for new users </br> | [How-to guides](/t/charmed-temporal-k8s-how-to-observability/11787) </br> Step-by-step guides covering key operations and common tasks |
-| [Reference](https://charmhub.io/temporal-k8s/actions) </br> Technical information - specifications, APIs, architecture                                                 | [Explanation](/t/charmed-temporal-k8s-explanations-architecture/11789) </br> Concepts - discussion and clarification of key topics     |
+|                                                                                                                                                                                                     |                                                                                                                                                                     |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Tutorial](https://discourse.charmhub.io/t/charmed-temporal-k8s-tutorial-introduction/11777) </br> Get started - a hands-on introduction to using Charmed Temporal K8s operator for new users </br> | [How-to guides](https://discourse.charmhub.io/t/charmed-temporal-k8s-how-to-observability/11787) </br> Step-by-step guides covering key operations and common tasks |
+| [Reference](https://charmhub.io/temporal-k8s/actions) </br> Technical information - specifications, APIs, architecture                                                                              | [Explanation](https://discourse.charmhub.io/t/charmed-temporal-k8s-explanations-architecture/11789) </br> Concepts - discussion and clarification of key topics     |
 
 # Navigation
 
-| Level | Path                | Navlink                                                                                                      |
-| ----- | ------------------- | ------------------------------------------------------------------------------------------------------------ |
-| 1     | tutorial            | [Tutorial]()                                                                                                 |
-| 2     | t-introduction      | [1. Introduction](/t/charmed-temporal-k8s-tutorial-introduction/11777)                                       |
-| 2     | t-setup-environment | [2. Environment Setup](/t/charmed-temporal-k8s-tutorial-environment-setup/11778)                             |
-| 2     | t-deploy-server     | [3. Deploy Temporal Server](/t/charmed-temporal-k8s-tutorial-deploy-temporal-server/11779)                   |
-| 2     | t-deploy-db         | [4. Deploy PostgreSQL Database](/t/charmed-temporal-k8s-tutorial-deploy-postgresql-database/11780)           |
-| 2     | t-deploy-admin      | [5. Deploy Temporal Admin](/t/charmed-temporal-k8s-tutorial-deploy-temporal-admin/11781)                     |
-| 2     | t-deploy-ui         | [6. Deploy Temporal Web UI](/t/charmed-temporal-k8s-tutorial-deploy-temporal-web-ui/11782)                   |
-| 2     | t-deploy-ingress    | [7. Deploy Nginx Ingress Integrator](/t/charmed-temporal-k8s-tutorial-deploy-nginx-ingress-integrator/11783) |
-| 2     | t-deploy-worker     | [8. Deploy Temporal Worker](/t/charmed-temporal-k8s-tutorial-deploy-temporal-worker/11784)                   |
-| 2     | t-run-workflow      | [9. Run Your First Workflow](/t/charmed-temporal-k8s-tutorial-run-your-first-workflow/11785)                 |
-| 2     | t-cleanup           | [10. Cleanup and Extra Info](/t/charmed-temporal-k8s-tutorial-cleanup-and-extra-info/11786)                  |
-| 1     | how-to              | [How to]()                                                                                                   |
-| 2     | h-authentication    | [Authentication](/t/charmed-temporal-k8s-how-to-authentication/12586)                                        |
-| 2     | h-authorization     | [Authorization](/t/charmed-temporal-k8s-how-to-authorization/12587)                                          |
-| 2     | h-observability     | [Observability](/t/charmed-temporal-k8s-how-to-observability/11787)                                          |
-| 2     | how-to-scaling      | [Scaling](/t/10840)                                                                                          |
-| 2     | h-tctl              | [TCTL](/t/charmed-temporal-k8s-how-to-tctl/11788)                                                            |
-| 1     | reference           | [Reference]()                                                                                                |
-| 2     | r-actions           | [Actions](https://charmhub.io/temporal-k8s/actions)                                                          |
-| 2     | r-configurations    | [Configurations](https://charmhub.io/temporal-k8s/configure)                                                 |
-| 2     | r-integrations      | [Integrations](https://charmhub.io/temporal-k8s/integrations)                                                |
-| 1     | e-architecture      | [Architecture](/t/charmed-temporal-k8s-explanations-architecture/11789)                                      |
+| Level | Path                | Navlink                                                                                                                                   |
+| ----- | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| 1     | tutorial            | [Tutorial]()                                                                                                                              |
+| 2     | t-introduction      | [1. Introduction](https://discourse.charmhub.io/t/charmed-temporal-k8s-tutorial-introduction/11777)                                       |
+| 2     | t-setup-environment | [2. Environment Setup](https://discourse.charmhub.io/t/charmed-temporal-k8s-tutorial-environment-setup/11778)                             |
+| 2     | t-deploy-server     | [3. Deploy Temporal Server](https://discourse.charmhub.io/t/charmed-temporal-k8s-tutorial-deploy-temporal-server/11779)                   |
+| 2     | t-deploy-db         | [4. Deploy PostgreSQL Database](https://discourse.charmhub.io/t/charmed-temporal-k8s-tutorial-deploy-postgresql-database/11780)           |
+| 2     | t-deploy-admin      | [5. Deploy Temporal Admin](https://discourse.charmhub.io/t/charmed-temporal-k8s-tutorial-deploy-temporal-admin/11781)                     |
+| 2     | t-deploy-ui         | [6. Deploy Temporal Web UI](https://discourse.charmhub.io/t/charmed-temporal-k8s-tutorial-deploy-temporal-web-ui/11782)                   |
+| 2     | t-deploy-ingress    | [7. Deploy Nginx Ingress Integrator](https://discourse.charmhub.io/t/charmed-temporal-k8s-tutorial-deploy-nginx-ingress-integrator/11783) |
+| 2     | t-deploy-worker     | [8. Deploy Temporal Worker](https://discourse.charmhub.io/t/charmed-temporal-k8s-tutorial-deploy-temporal-worker/11784)                   |
+| 2     | t-run-workflow      | [9. Run Your First Workflow](https://discourse.charmhub.io/t/charmed-temporal-k8s-tutorial-run-your-first-workflow/11785)                 |
+| 2     | t-cleanup           | [10. Cleanup and Extra Info](https://discourse.charmhub.io/t/charmed-temporal-k8s-tutorial-cleanup-and-extra-info/11786)                  |
+| 1     | how-to              | [How to]()                                                                                                                                |
+| 2     | h-authentication    | [Authentication](https://discourse.charmhub.io/t/charmed-temporal-k8s-how-to-authentication/12586)                                        |
+| 2     | h-authorization     | [Authorization](https://discourse.charmhub.io/t/charmed-temporal-k8s-how-to-authorization/12587)                                          |
+| 2     | h-observability     | [Observability](https://discourse.charmhub.io/t/charmed-temporal-k8s-how-to-observability/11787)                                          |
+| 2     | h-scaling           | [Scaling](https://discourse.charmhub.io/t/10840)                                                                                          |
+| 2     | h-tctl              | [TCTL](https://discourse.charmhub.io/t/charmed-temporal-k8s-how-to-tctl/11788)                                                            |
+| 2     | h-server-upgrades   | [Server Upgrades](CREATE_DISCOURSE_PAGE_AFTER_PR_APPROVAL)                                                                                |
+| 1     | reference           | [Reference]()                                                                                                                             |
+| 2     | r-actions           | [Actions](https://charmhub.io/temporal-k8s/actions)                                                                                       |
+| 2     | r-configurations    | [Configurations](https://charmhub.io/temporal-k8s/configure)                                                                              |
+| 2     | r-integrations      | [Integrations](https://charmhub.io/temporal-k8s/integrations)                                                                             |
+| 1     | e-architecture      | [Architecture](https://discourse.charmhub.io/t/charmed-temporal-k8s-explanations-architecture/11789)                                      |
 
 # Redirects
 

--- a/documentation/tutorial/01-introduction.md
+++ b/documentation/tutorial/01-introduction.md
@@ -5,15 +5,15 @@ day 0 to day 2 on [Temporal](https://temporal.io/). It is an open source,
 end-to-end, production-ready workflow engine on top of [Juju](https://juju.is/).
 This tutorial will cover the following:
 
-- [Environment Setup](/t/charmed-temporal-k8s-tutorial-environment-setup/11778)
-- [Deploy Temporal Server](/t/charmed-temporal-k8s-tutorial-deploy-temporal-server/11779)
-- [Deploy PostgreSQL Database](/t/charmed-temporal-k8s-tutorial-deploy-postgresql-database/11780)
-- [Deploy Temporal Admin](/t/charmed-temporal-k8s-tutorial-deploy-temporal-admin/11781)
-- [Deploy Temporal Web UI](/t/charmed-temporal-k8s-tutorial-deploy-temporal-web-ui/11782)
-- [Deploy Nginx Ingress Integrator](/t/charmed-temporal-k8s-tutorial-deploy-nginx-ingress-integrator/11783)
-- [Deploy Temporal Worker](/t/charmed-temporal-k8s-tutorial-deploy-temporal-worker/11784)
-- [Run Your First Workflow](/t/charmed-temporal-k8s-tutorial-run-your-first-workflow/11785)
-- [Cleanup and Extra Info](/t/charmed-temporal-k8s-tutorial-cleanup-and-extra-info/11786)
+- [Environment Setup](https://discourse.charmhub.io/t/charmed-temporal-k8s-tutorial-environment-setup/11778)
+- [Deploy Temporal Server](https://discourse.charmhub.io/t/charmed-temporal-k8s-tutorial-deploy-temporal-server/11779)
+- [Deploy PostgreSQL Database](https://discourse.charmhub.io/t/charmed-temporal-k8s-tutorial-deploy-postgresql-database/11780)
+- [Deploy Temporal Admin](https://discourse.charmhub.io/t/charmed-temporal-k8s-tutorial-deploy-temporal-admin/11781)
+- [Deploy Temporal Web UI](https://discourse.charmhub.io/t/charmed-temporal-k8s-tutorial-deploy-temporal-web-ui/11782)
+- [Deploy Nginx Ingress Integrator](https://discourse.charmhub.io/t/charmed-temporal-k8s-tutorial-deploy-nginx-ingress-integrator/11783)
+- [Deploy Temporal Worker](https://discourse.charmhub.io/t/charmed-temporal-k8s-tutorial-deploy-temporal-worker/11784)
+- [Run Your First Workflow](https://discourse.charmhub.io/t/charmed-temporal-k8s-tutorial-run-your-first-workflow/11785)
+- [Cleanup and Extra Info](https://discourse.charmhub.io/t/charmed-temporal-k8s-tutorial-cleanup-and-extra-info/11786)
 
 This tutorial assumes a basic understanding of the following:
 

--- a/documentation/tutorial/02-environment.md
+++ b/documentation/tutorial/02-environment.md
@@ -86,4 +86,4 @@ juju status
 ```
 
 > **See next:
-> [Deploying Temporal Server](/t/charmed-temporal-k8s-tutorial-deploy-temporal-server/11779)**
+> [Deploying Temporal Server](https://discourse.charmhub.io/t/charmed-temporal-k8s-tutorial-deploy-temporal-server/11779)**

--- a/documentation/tutorial/03-deploy-server.md
+++ b/documentation/tutorial/03-deploy-server.md
@@ -55,4 +55,4 @@ further inspect juju logs, can watch for logs with `juju debug-log`. More info
 on logging at [juju logs](https://juju.is/docs/olm/juju-logs).
 
 > **See next:
-> [Deploy PostgreSQL Database](/t/charmed-temporal-k8s-tutorial-deploy-postgresql-database/11780)**
+> [Deploy PostgreSQL Database](https://discourse.charmhub.io/t/charmed-temporal-k8s-tutorial-deploy-postgresql-database/11780)**

--- a/documentation/tutorial/04-deploy-db.md
+++ b/documentation/tutorial/04-deploy-db.md
@@ -67,4 +67,4 @@ temporal-k8s:peer                 temporal-k8s:peer              temporal       
 ```
 
 > **See next:
-> [Deploy Temporal Admin](/t/charmed-temporal-k8s-tutorial-deploy-temporal-admin/11781)**
+> [Deploy Temporal Admin](https://discourse.charmhub.io/t/charmed-temporal-k8s-tutorial-deploy-temporal-admin/11781)**

--- a/documentation/tutorial/05-deploy-admin.md
+++ b/documentation/tutorial/05-deploy-admin.md
@@ -72,7 +72,7 @@ You can run the following command to create the initial Temporal namespace:
 
 ```bash
 # Create default namespace:
-juju run temporal-admin-k8s/0 tctl args="--ns default namespace register -rd 3"
+juju run temporal-admin-k8s/0 tctl args="--ns default namespace register -rd 3" --wait 1m
 
 # Output:
 Running operation 19 with 1 task
@@ -87,4 +87,4 @@ result: command succeeded
 ```
 
 > **See next:
-> [Deploy Temporal Web UI](/t/charmed-temporal-k8s-tutorial-deploy-temporal-web-ui/11782)**
+> [Deploy Temporal Web UI](https://discourse.charmhub.io/t/charmed-temporal-k8s-tutorial-deploy-temporal-web-ui/11782)**

--- a/documentation/tutorial/06-deploy-ui.md
+++ b/documentation/tutorial/06-deploy-ui.md
@@ -83,4 +83,4 @@ Workflows Found" as seen below.
 ![Temporal Web UI](../media/temporal-web-ui.png)
 
 > **See next:
-> [Deploy Nginx Ingress Integrator](/t/charmed-temporal-k8s-tutorial-deploy-nginx-ingress-integrator/11783)**
+> [Deploy Nginx Ingress Integrator](https://discourse.charmhub.io/t/charmed-temporal-k8s-tutorial-deploy-nginx-ingress-integrator/11783)**

--- a/documentation/tutorial/07-deploy-ingress.md
+++ b/documentation/tutorial/07-deploy-ingress.md
@@ -211,4 +211,4 @@ client = await Client.connect("temporal-k8s", tls=tls)
 ```
 
 > **See next:
-> [Deploy Temporal Worker](/t/charmed-temporal-k8s-tutorial-deploy-temporal-worker/11784)**
+> [Deploy Temporal Worker](https://discourse.charmhub.io/t/charmed-temporal-k8s-tutorial-deploy-temporal-worker/11784)**

--- a/documentation/tutorial/08-deploy-worker.md
+++ b/documentation/tutorial/08-deploy-worker.md
@@ -109,4 +109,4 @@ At this point, we have a Temporal worker connected to our Temporal server on the
 `default` namespace listening for tasks on the `test-queue` task queue.
 
 > **See next:
-> [Run Your First Workflow](/t/charmed-temporal-k8s-tutorial-run-your-first-workflow/11785)**
+> [Run Your First Workflow](https://discourse.charmhub.io/t/charmed-temporal-k8s-tutorial-run-your-first-workflow/11785)**

--- a/documentation/tutorial/09-run-workflow.md
+++ b/documentation/tutorial/09-run-workflow.md
@@ -63,4 +63,4 @@ generated in the ingress step of this tutorial as part of your
 making requests to the Temporal server.
 
 > **See next:
-> [Cleanup your environment](/t/charmed-temporal-k8s-tutorial-cleanup-and-extra-info/11786)**
+> [Cleanup your environment](https://discourse.charmhub.io/t/charmed-temporal-k8s-tutorial-cleanup-and-extra-info/11786)**

--- a/documentation/tutorial/10-cleanup.md
+++ b/documentation/tutorial/10-cleanup.md
@@ -30,7 +30,9 @@ If you’re looking for what to do next you can:
   and
   [observability](https://discourse.charmhub.io/t/charmed-temporal-k8s-how-to-observability/11787).
 - Explore
-  [Temporal client authentication and encryption](https://pypi.org/project/temporal-lib-py/)
+  Temporal client authentication and encryption:
+    - [Python](https://github.com/canonical/temporal-lib-py)
+    - [Go](https://github.com/canonical/temporal-lib-go)
 - Explore [workflow samples](https://github.com/temporalio/samples-python)
 - Report any problems you encountered for any of the following charms:
   - [Temporal Server](https://github.com/canonical/temporal-k8s-operator/issues)


### PR DESCRIPTION
This PR addresses the following:

- Adds a "How to" documentation page on how to perform server upgrades.
- Updates tctl documentation.
- Updates authorization documentation based on changes introduced in #29.
- Fixes documentation links so that they are accessible in Github.