### PR TITLE
Make number of history shards configurable

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -9,6 +9,16 @@ options:
       can be either run in a single container or spread across multiple
       containers, which allows to independently scale each component.
     type: string
+  num-history-shards:
+    default: 0
+    description: |
+      The number of concurrent database operations that can occur for a Temporal Cluster.
+      This value can only be set once at deployment time. Setting the value after it has
+      already been set will send the charm into a blocked state until it is set back to the
+      original value.
+
+      This value must be consistent across all components if using a scaled deployment.
+    type: int
   log-level:
     default: info
     description: Temporal server logging level.

--- a/config.yaml
+++ b/config.yaml
@@ -14,7 +14,7 @@ options:
       The number of concurrent database operations that can occur for a Temporal Cluster.
       This value can only be set once at deployment time. Setting the value after it has
       already been set will send the charm into a blocked state until it is set back to the
-      original value.
+      original value. This value must be set to a positive power of 2 (e.g. 1, 2, 4).
 
       This value must be consistent across all components if using a scaled deployment.
     type: int

--- a/config.yaml
+++ b/config.yaml
@@ -10,7 +10,6 @@ options:
       containers, which allows to independently scale each component.
     type: string
   num-history-shards:
-    default: 0
     description: |
       The number of concurrent database operations that can occur for a Temporal Cluster.
       This value can only be set once at deployment time. Setting the value after it has

--- a/src/charm.py
+++ b/src/charm.py
@@ -323,8 +323,10 @@ class TemporalK8SCharm(CharmBase):
 
         num_history_shards = self._state.num_history_shards
         if num_history_shards is None:
-            if self.config.get("num-history-shards", "") == "":
-                raise ValueError("value of 'num-history-shards' config must be set")
+            if self.config.get("num-history-shards", "") == "" or self.config.get("num-history-shards") <= 0:
+                raise ValueError(
+                    "value of 'num-history-shards' config must be set to a positive power of 2 (e.g. 1, 2, 4)"
+                )
             self._state.num_history_shards = self.config.get("num-history-shards")
         elif num_history_shards != self.config["num-history-shards"]:
             message = f"value of 'num-history-shards' config cannot be changed after deployment. Value should be {num_history_shards}"

--- a/src/charm.py
+++ b/src/charm.py
@@ -322,15 +322,14 @@ class TemporalK8SCharm(CharmBase):
                 raise ValueError(f"error in services config: invalid service {service!r}")
 
         num_history_shards = self._state.num_history_shards
-        if self.config["num-history-shards"] == 0 and num_history_shards is None:
-            raise ValueError("value of 'num-history-shards' config must be greater than 0")
-
         if num_history_shards is None:
-            self._state.num_history_shards = self.config["num-history-shards"]
+            if self.config.get("num-history-shards", "") == "":
+                raise ValueError("value of 'num-history-shards' config must be set")
+            self._state.num_history_shards = self.config.get("num-history-shards")
         elif num_history_shards != self.config["num-history-shards"]:
-            raise ValueError(
-                f"value of 'num-history-shards' config cannot be changed after deployment. Value should be {num_history_shards}"
-            )
+            message = f"value of 'num-history-shards' config cannot be changed after deployment. Value should be {num_history_shards}"
+            logger.error(message)
+            raise ValueError(message)
 
         # Validate admin relation.
         self.database_connections()

--- a/src/charm.py
+++ b/src/charm.py
@@ -321,6 +321,17 @@ class TemporalK8SCharm(CharmBase):
             if not any(service == item.value for item in ValidServiceTypes):
                 raise ValueError(f"error in services config: invalid service {service!r}")
 
+        num_history_shards = self._state.num_history_shards
+        if self.config["num-history-shards"] == 0 and num_history_shards is None:
+            raise ValueError("value of 'num-history-shards' config must be greater than 0")
+
+        if num_history_shards is None:
+            self._state.num_history_shards = self.config["num-history-shards"]
+        elif num_history_shards != self.config["num-history-shards"]:
+            raise ValueError(
+                f"value of 'num-history-shards' config cannot be changed after deployment. Value should be {num_history_shards}"
+            )
+
         # Validate admin relation.
         self.database_connections()
         if not self._state.schema_ready:
@@ -407,6 +418,7 @@ class TemporalK8SCharm(CharmBase):
                 "VISIBILITY_USER": visibility_conn["user"],
                 "VISIBILITY_PSWD": visibility_conn["password"],
                 "TEMPORAL_BROADCAST_ADDRESS": str(self.model.get_binding("peer").network.bind_address),
+                "NUM_HISTORY_SHARDS": self._state.num_history_shards,
             }
         )
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -28,7 +28,7 @@ async def deploy(ops_test: OpsTest):
 
     # Deploy temporal server, temporal admin and postgresql charms.
     asyncio.gather(
-        ops_test.model.deploy(charm, resources=resources, application_name=APP_NAME),
+        ops_test.model.deploy(charm, resources=resources, application_name=APP_NAME, config={"num-history-shards": 1}),
         ops_test.model.deploy(APP_NAME_ADMIN, channel="edge"),
         ops_test.model.deploy(APP_NAME_UI, channel="edge"),
         ops_test.model.deploy("postgresql-k8s", channel="14/stable", trust=True),

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -128,7 +128,9 @@ async def simulate_charm_crash(ops_test: OpsTest):
     resources = {"temporal-server-image": METADATA["containers"]["temporal"]["upstream-source"]}
 
     # Deploy temporal server, temporal admin and postgresql charms.
-    await ops_test.model.deploy(charm, resources=resources, application_name=APP_NAME, num_units=1)
+    await ops_test.model.deploy(
+        charm, resources=resources, application_name=APP_NAME, num_units=1, config={"num-history-shards": 1}
+    )
 
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(apps=[APP_NAME], status="blocked", raise_on_blocked=False, timeout=600)

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -37,7 +37,10 @@ async def deploy(ops_test: OpsTest):
     for i in range(4):
         # for service in ALL_SERVICES:
         await ops_test.model.deploy(
-            charm, resources=resources, application_name=ALL_SERVICES[i], config={"services": ALL_CONFIG[i]}
+            charm,
+            resources=resources,
+            application_name=ALL_SERVICES[i],
+            config={"services": ALL_CONFIG[i], "num-history-shards": 1},
         )
 
     await ops_test.model.deploy(APP_NAME_ADMIN, channel="edge")

--- a/tests/integration/test_upgrades.py
+++ b/tests/integration/test_upgrades.py
@@ -66,6 +66,10 @@ class TestUpgrade:
         # This is to accmmodate for a self-resolving error which sometimes appears when Temporal
         # services attempt to connect to the cluster before the application is ready.
         await ops_test.model.applications[APP_NAME].refresh(path=str(charm), resources=resources)
+        await ops_test.model.applications[APP_NAME].set_config(
+            {"num-history-shards": "1"},
+        )
+
         await ops_test.model.wait_for_idle(
             apps=[APP_NAME], raise_on_error=False, status="active", raise_on_blocked=False, timeout=600
         )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -74,7 +74,10 @@ class TestCharm(TestCase):
         harness.charm.on.temporal_pebble_ready.emit(container)
 
         # The BlockStatus is set with a message.
-        self.assertEqual(harness.model.unit.status, BlockedStatus("value of 'num-history-shards' config must be set"))
+        self.assertEqual(
+            harness.model.unit.status,
+            BlockedStatus("value of 'num-history-shards' config must be set to a positive power of 2 (e.g. 1, 2, 4)"),
+        )
 
     def test_blocked_by_db(self):
         """The charm is blocked without a db:pgsql relation with a ready master."""

--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,7 @@ commands =
     isort --check-only --diff {[vars]src_path} {[vars]tst_path}
     black --check --diff {[vars]src_path} {[vars]tst_path}
     mypy {[vars]all_path} --ignore-missing-imports --follow-imports=skip --install-types --non-interactive
-    pylint {[vars]all_path} --disable=E0401,W1203,W0613,W0718,R0903,W1514,C0103,R0913,C0301,W0212,R0902,C0104,W0640,R0801,W0511,R0914
+    pylint {[vars]all_path} --disable=E0401,W1203,W0613,W0718,R0903,W1514,C0103,R0913,C0301,W0212,R0902,C0104,W0640,R0801,W0511,R0914,R0912
 
 [testenv:unit]
 description = Run tests


### PR DESCRIPTION
This PR makes the number of [history shards](https://docs.temporal.io/clusters#history-shard) a configurable value at deployment time. This is a value that can only be set once at deployment time, so the mechanism to enforce this has been implemented at the charm level.

Note: Prior to this change, the number of history shards was set to 4 by default. Existing charmed Temporal deployments upgrading to this revision of the charm will be required to set the `num-history-shards` config to 4 for the charm to continue functioning.