### PR TITLE
CSS-7952: Add documentation landing pages and fix db relation removal bug

### DIFF
--- a/documentation/how-to/index.md
+++ b/documentation/how-to/index.md
@@ -1,0 +1,31 @@
+# Charmed Temporal How-to
+
+The _How-to_ guides in this section give directions on how to achieve your goals
+when configuring, managing or using Charmed Temporal. These _How-to_ guides are
+more useful when you are familiar with Temporal and seek to achieve specific
+goals such as enabling auth, observability and performing server upgrades.
+
+The How-to guides will cover the following:
+
+- [Authentication](https://discourse.charmhub.io/t/charmed-temporal-k8s-how-to-authentication/12586):
+  for enabling client authentication using Google OAuth.
+- [Authorization](https://discourse.charmhub.io/t/charmed-temporal-k8s-how-to-authorization/12587):
+  for enabling client authorization using OpenFGA.
+- [Observability](https://discourse.charmhub.io/t/charmed-temporal-k8s-how-to-observability/11787):
+  for enabling observability metrics through the
+  [Canonical Observabiliy Stack](https://charmhub.io/topics/canonical-observability-stack).
+- [Scaling](https://discourse.charmhub.io/t/10840): for horizontally scaling
+  your Charmed Temporal deployment.
+- [TCTL](https://discourse.charmhub.io/t/charmed-temporal-k8s-how-to-tctl/11788):
+  for using the tctl command line tool.
+- [Server Upgrades](https://discourse.charmhub.io/t/charmed-temporal-k8s-how-to-server-upgrades/13105):
+  for safely upgrading Charmed Temporal server.
+- [Enabling Archival](https://discourse.charmhub.io/t/charmed-temporal-k8s-how-to-enable-archival/13106):
+  for enabling workflow event history archival to an S3 bucket.
+
+Also check out the
+[Tutorials](https://discourse.charmhub.io/t/charmed-temporal-k8s-tutorial-introduction/11777)
+for step-by-step instructions that help you get started with Charmed Temporal,
+as well as the
+[Reference](https://discourse.charmhub.io/t/charmed-temporal-k8s-reference-index/13741)
+section for other helpful information.

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -29,7 +29,7 @@ manner for production purposes.
 
 | Level | Path                | Navlink                                                                                                                                   |
 | ----- | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| 1     | tutorial            | [Tutorial]()                                                                                                                              |
+| 1     | tutorial            | [Tutorial](https://discourse.charmhub.io/t/charmed-temporal-k8s-tutorial-introduction/11777)                                              |
 | 2     | t-introduction      | [1. Introduction](https://discourse.charmhub.io/t/charmed-temporal-k8s-tutorial-introduction/11777)                                       |
 | 2     | t-setup-environment | [2. Environment Setup](https://discourse.charmhub.io/t/charmed-temporal-k8s-tutorial-environment-setup/11778)                             |
 | 2     | t-deploy-server     | [3. Deploy Temporal Server](https://discourse.charmhub.io/t/charmed-temporal-k8s-tutorial-deploy-temporal-server/11779)                   |
@@ -40,7 +40,7 @@ manner for production purposes.
 | 2     | t-deploy-worker     | [8. Deploy Temporal Worker](https://discourse.charmhub.io/t/charmed-temporal-k8s-tutorial-deploy-temporal-worker/11784)                   |
 | 2     | t-run-workflow      | [9. Run Your First Workflow](https://discourse.charmhub.io/t/charmed-temporal-k8s-tutorial-run-your-first-workflow/11785)                 |
 | 2     | t-cleanup           | [10. Cleanup and Extra Info](https://discourse.charmhub.io/t/charmed-temporal-k8s-tutorial-cleanup-and-extra-info/11786)                  |
-| 1     | how-to              | [How to]()                                                                                                                                |
+| 1     | how-to              | [How to](https://discourse.charmhub.io/t/charmed-temporal-k8s-how-to-index/13740)                                                         |
 | 2     | h-authentication    | [Authentication](https://discourse.charmhub.io/t/charmed-temporal-k8s-how-to-authentication/12586)                                        |
 | 2     | h-authorization     | [Authorization](https://discourse.charmhub.io/t/charmed-temporal-k8s-how-to-authorization/12587)                                          |
 | 2     | h-observability     | [Observability](https://discourse.charmhub.io/t/charmed-temporal-k8s-how-to-observability/11787)                                          |
@@ -48,7 +48,7 @@ manner for production purposes.
 | 2     | h-tctl              | [TCTL](https://discourse.charmhub.io/t/charmed-temporal-k8s-how-to-tctl/11788)                                                            |
 | 2     | h-server-upgrades   | [Server Upgrades](https://discourse.charmhub.io/t/charmed-temporal-k8s-how-to-server-upgrades/13105)                                      |
 | 2     | h-archival          | [Enable Archival](https://discourse.charmhub.io/t/charmed-temporal-k8s-how-to-enable-archival/13106)                                      |
-| 1     | reference           | [Reference]()                                                                                                                             |
+| 1     | reference           | [Reference](https://discourse.charmhub.io/t/charmed-temporal-k8s-reference-index/13741)                                                   |
 | 2     | r-actions           | [Actions](https://charmhub.io/temporal-k8s/actions)                                                                                       |
 | 2     | r-configurations    | [Configurations](https://charmhub.io/temporal-k8s/configure)                                                                              |
 | 2     | r-integrations      | [Integrations](https://charmhub.io/temporal-k8s/integrations)                                                                             |

--- a/documentation/reference/index.md
+++ b/documentation/reference/index.md
@@ -1,0 +1,24 @@
+# Charmed Temporal Reference
+
+The _Reference_ guides in this section provide additional information about
+using Charmed Temporal, available integrations, actions and configuration
+options.
+
+The Reference guides will cover the following:
+
+- [Actions](https://charmhub.io/temporal-k8s/actions): a list of
+  [juju actions](https://juju.is/docs/juju/action) that can be run on Charmed
+  Temporal units.
+- [Configurations](https://charmhub.io/temporal-k8s/configure): a list of
+  [configuration options](https://juju.is/docs/juju/configuration#heading--application-configuration)
+  that can be affect the behavior of Charmed Temporal.
+- [Integrations](https://charmhub.io/temporal-k8s/integrations): a list of
+  available [integrations](https://juju.is/docs/juju/relation) with different
+  charmed operators.
+
+Also check out the
+[Tutorials](https://discourse.charmhub.io/t/charmed-temporal-k8s-tutorial-introduction/11777)
+for step-by-step instructions that help you get started with Charmed Temporal,
+as well as the
+[How-to](https://discourse.charmhub.io/t/charmed-temporal-k8s-how-to-index/13740)
+section for other helpful information.

--- a/lib/charms/nginx_ingress_integrator/v0/nginx_route.py
+++ b/lib/charms/nginx_ingress_integrator/v0/nginx_route.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # Licensed under the Apache2.0. See LICENSE file in charm source for details.
 """Library for the nginx-route relation.
 
@@ -86,7 +86,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 __all__ = ["require_nginx_route", "provide_nginx_route"]
 
@@ -404,7 +404,8 @@ def provide_nginx_route(
         RuntimeError: If provide_nginx_route was invoked twice with
             the same nginx-route relation name
     """
-    if __provider_references.get(charm, {}).get(nginx_route_relation_name) is not None:
+    ref_dict: typing.Dict[str, typing.Any] = __provider_references.get(charm, {})
+    if ref_dict.get(nginx_route_relation_name) is not None:
         raise RuntimeError(
             "provide_nginx_route was invoked twice with the same nginx-route relation name"
         )

--- a/src/relations/postgresql.py
+++ b/src/relations/postgresql.py
@@ -91,6 +91,9 @@ class Postgresql(framework.Object):
             rel_name: Name of the relation to update.
             db_conn: Database connection dict.
         """
+        if self.charm._state.database_connections is None:
+            self.charm._state.database_connections = {}
+        
         database_connections = self.charm._state.database_connections
         database_connections[rel_name] = db_conn
         self.charm._state.database_connections = database_connections

--- a/src/relations/postgresql.py
+++ b/src/relations/postgresql.py
@@ -93,7 +93,7 @@ class Postgresql(framework.Object):
         """
         if self.charm._state.database_connections is None:
             self.charm._state.database_connections = {}
-        
+
         database_connections = self.charm._state.database_connections
         database_connections[rel_name] = db_conn
         self.charm._state.database_connections = database_connections


### PR DESCRIPTION
This PR does the following:

- Fixes a small bug that popped up when removing the relation between the `temporal-k8s` and `postgresql-k8s` charms.
- Adds documentation landing pages.
- Updates charm libraries.