### PR TITLE
Upgrade server to v1.23.1

### DIFF
--- a/documentation/how-to/upgrade-server.md
+++ b/documentation/how-to/upgrade-server.md
@@ -48,10 +48,11 @@ Server._
 ## Appendix
 
 The table below shows a mapping between the Temporal K8s charms and the Temporal
-server versions. It can be used as a reference for upgrading your charm
-revisions in line with the Temporal server version so as to avoid any breaking
-changes.
+server versions on the **edge** channel. It can be used as a reference for
+upgrading your charm revisions in line with the Temporal server version so as to
+avoid any breaking changes.
 
 | Temporal Server Charm Revision | Temporal Admin Charm Revision | Temporal Server Version |
 | :----------------------------: | :---------------------------: | :---------------------: |
-|             20-21              |              8-9              |         v1.21.5         |
+|             20-24              |              8-9              |         v1.21.5         |
+|              25-               |              10-              |         v1.23.1         |

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -480,7 +480,9 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 28
+LIBPATCH = 29
+
+PYDEPS = ["cosl"]
 
 logger = logging.getLogger(__name__)
 

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -178,7 +178,7 @@ configure the following scrape-related settings, which behave as described by th
 - `scrape_timeout`
 - `proxy_url`
 - `relabel_configs`
-- `metrics_relabel_configs`
+- `metric_relabel_configs`
 - `sample_limit`
 - `label_limit`
 - `label_name_length_limit`
@@ -362,7 +362,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 44
+LIBPATCH = 47
 
 PYDEPS = ["cosl"]
 
@@ -377,7 +377,7 @@ ALLOWED_KEYS = {
     "scrape_timeout",
     "proxy_url",
     "relabel_configs",
-    "metrics_relabel_configs",
+    "metric_relabel_configs",
     "sample_limit",
     "label_limit",
     "label_name_length_limit",
@@ -521,8 +521,8 @@ class PrometheusConfig:
                         # for such a target. Therefore labeling with Juju topology, excluding the
                         # unit name.
                         non_wildcard_static_config["labels"] = {
-                            **non_wildcard_static_config.get("labels", {}),
                             **topology.label_matcher_dict,
+                            **non_wildcard_static_config.get("labels", {}),
                         }
 
                     non_wildcard_static_configs.append(non_wildcard_static_config)
@@ -547,9 +547,9 @@ class PrometheusConfig:
                         if topology:
                             # Add topology labels
                             modified_static_config["labels"] = {
-                                **modified_static_config.get("labels", {}),
                                 **topology.label_matcher_dict,
                                 **{"juju_unit": unit_name},
+                                **modified_static_config.get("labels", {}),
                             }
 
                             # Instance relabeling for topology should be last in order.
@@ -1537,12 +1537,11 @@ class MetricsEndpointProvider(Object):
             relation.data[self._charm.app]["scrape_metadata"] = json.dumps(self._scrape_metadata)
             relation.data[self._charm.app]["scrape_jobs"] = json.dumps(self._scrape_jobs)
 
-            if alert_rules_as_dict:
-                # Update relation data with the string representation of the rule file.
-                # Juju topology is already included in the "scrape_metadata" field above.
-                # The consumer side of the relation uses this information to name the rules file
-                # that is written to the filesystem.
-                relation.data[self._charm.app]["alert_rules"] = json.dumps(alert_rules_as_dict)
+            # Update relation data with the string representation of the rule file.
+            # Juju topology is already included in the "scrape_metadata" field above.
+            # The consumer side of the relation uses this information to name the rules file
+            # that is written to the filesystem.
+            relation.data[self._charm.app]["alert_rules"] = json.dumps(alert_rules_as_dict)
 
     def _set_unit_ip(self, _=None):
         """Set unit host address.

--- a/src/charm.py
+++ b/src/charm.py
@@ -341,7 +341,10 @@ class TemporalK8SCharm(CharmBase):
                 raise ValueError(
                     "value of 'num-history-shards' config must be set to a positive power of 2 (e.g. 1, 2, 4)"
                 )
-            self._state.num_history_shards = self.config.get("num-history-shards")
+
+            if self.unit.is_leader():
+                self._state.num_history_shards = self.config.get("num-history-shards")
+
         elif num_history_shards != self.config["num-history-shards"]:
             message = f"value of 'num-history-shards' config cannot be changed after deployment. Value should be {num_history_shards}"
             logger.error(message)

--- a/src/literals.py
+++ b/src/literals.py
@@ -39,7 +39,7 @@ SERVICE_PORTS = {
 }
 
 PROMETHEUS_PORT = 9090
-WORKLOAD_VERSION = "1.21.5"
+WORKLOAD_VERSION = "1.23.1"
 
 
 class ValidServiceTypes(Enum):

--- a/src/relations/postgresql.py
+++ b/src/relations/postgresql.py
@@ -44,11 +44,11 @@ class Postgresql(framework.Object):
         Args:
             event: The event triggered when the relation changed.
         """
-        if not self.charm._state.is_ready():
-            event.defer()
+        if not self.charm.unit.is_leader():
             return
 
-        if not self.charm.unit.is_leader():
+        if not self.charm._state.is_ready():
+            event.defer()
             return
 
         self.charm.unit.status = WaitingStatus(f"handling {event.relation.name} change")
@@ -76,13 +76,15 @@ class Postgresql(framework.Object):
         Args:
             event: The event triggered when the relation changed.
         """
+        if not self.charm.unit.is_leader():
+            return
+
         if not self.charm._state.is_ready():
             event.defer()
             return
 
-        if self.charm.unit.is_leader():
-            self._update_db_connections(event.relation.name, None)
-            self.charm._update(event)
+        self._update_db_connections(event.relation.name, None)
+        self.charm._update(event)
 
     def _update_db_connections(self, rel_name, db_conn):
         """Assign nested value in peer relation.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -36,7 +36,7 @@ async def deploy(ops_test: OpsTest):
 
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(
-            apps=["postgresql-k8s"], status="active", raise_on_blocked=False, timeout=600
+            apps=["postgresql-k8s"], status="active", raise_on_blocked=False, timeout=1200
         )
         await ops_test.model.wait_for_idle(
             apps=[APP_NAME, APP_NAME_ADMIN, APP_NAME_UI], status="blocked", raise_on_blocked=False, timeout=600

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -37,7 +37,7 @@ class TestAuth:
         await ops_test.model.applications[APP_NAME].set_config(
             {"auth-enabled": "true", "auth-admin-groups": "red,green"}
         )
-        await ops_test.model.deploy("openfga-k8s", channel="latest/edge", revision=27)
+        await ops_test.model.deploy("openfga-k8s", channel="latest/edge")
 
         async with ops_test.fast_forward():
             await ops_test.model.wait_for_idle(

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -37,7 +37,7 @@ class TestAuth:
         await ops_test.model.applications[APP_NAME].set_config(
             {"auth-enabled": "true", "auth-admin-groups": "red,green"}
         )
-        await ops_test.model.deploy("openfga-k8s", channel="latest/edge")
+        await ops_test.model.deploy("openfga-k8s", channel="2.0/stable")
 
         async with ops_test.fast_forward():
             await ops_test.model.wait_for_idle(

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -37,13 +37,14 @@ class TestAuth:
         await ops_test.model.applications[APP_NAME].set_config(
             {"auth-enabled": "true", "auth-admin-groups": "red,green"}
         )
-        await ops_test.model.deploy("openfga-k8s", channel="latest/edge")
+        await ops_test.model.deploy("openfga-k8s", channel="latest/edge", revision=27)
 
         async with ops_test.fast_forward():
             await ops_test.model.wait_for_idle(
                 apps=[APP_NAME, "openfga-k8s"],
                 status="blocked",
                 raise_on_blocked=False,
+                raise_on_error=False,
                 timeout=1200,
             )
 


### PR DESCRIPTION
This PR is for triggering a Temporal server charm re-release to Charmhub with the latest image uploaded [here](https://github.com/canonical/charmed-temporal-image/pkgs/container/temporal-server), which upgrades the Temporal server image to `v1.23.1`. More info on this change can be found [here](https://github.com/canonical/charmed-temporal-image/pull/9).