### PR TITLE
CSS-9372: Add namespace rate limits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,10 +82,19 @@ deployment, follow the following steps:
     juju deploy ./temporal-k8s_ubuntu-22.04-amd64.charm --resource temporal-server-image=ghcr.io/canonical/temporal-server:latest
 
     # Deploy admin charm (Only if modifying admin charm, otherwise deploy as shown below):
-    juju deploy ./temporal-admin-k8s_ubuntu-22.04-amd64.charm --resource temporal-admin-image=temporalio/admin-tools:1.21.5
+    juju deploy ./temporal-admin-k8s_ubuntu-22.04-amd64.charm --resource temporal-admin-image=temporalio/admin-tools:1.23.1
 
     # Deploy ui charm (Only if modifying UI charm, otherwise deploy as shown below):
-    juju deploy ./temporal-ui-k8s_ubuntu-22.04-amd64.charm --resource temporal-ui-image=temporalio/ui:2.21.3
+    juju deploy ./temporal-ui-k8s_ubuntu-22.04-amd64.charm --resource temporal-ui-image=temporalio/ui:2.27.1
+
+    # Refresh charm
+    juju refresh --path="./temporal-k8s_ubuntu-22.04-amd64.charm" temporal-k8s --force-units --resource temporal-server-image=ghcr.io/canonical/temporal-server:latest
+
+    # Refresh the admin charm
+    juju refresh --path="./temporal-admin-k8s_ubuntu-22.04-amd64.charm" temporal-admin-k8s --force-units --resource temporal-admin-image=temporalio/admin-tools:1.23.1
+
+    # Refresh the ui charm
+    juju refresh --path="./temporal-ui-k8s_ubuntu-22.04-amd64.charm" temporal-ui-k8s --force-units --resource temporal-ui-image=temporalio/ui:2.27.1
 
     # Relate operator to postgres:
     juju deploy postgresql-k8s --channel 14/stable --trust

--- a/config.yaml
+++ b/config.yaml
@@ -103,3 +103,19 @@ options:
         Maximum time a database connection is held with the visibility database.
     default: "1h"
     type: string
+
+  global-rps-limit:
+    description: |
+        Global limit for requests per second per namespace.
+    default: 2000
+    type: int
+
+  namespace-rps-limit:
+    description: |
+        Pipe-separated definition of namespace requests per second limits.
+
+        e.g. "namespaceA:100|namespaceB:200" means namespaceA will have an RPS
+        limit of 100, namespaceB of 200, and any other namespaces not defined
+        in this config will fall back to the value defined in `global-rps-limit`.
+    default: ""
+    type: string

--- a/documentation/how-to/scaling.md
+++ b/documentation/how-to/scaling.md
@@ -60,15 +60,12 @@ services to the same database and admin charms:
 ```bash
 juju relate temporal-k8s-history:db postgresql-k8s:database
 juju relate temporal-k8s-history:visibility postgresql-k8s:database
-juju relate temporal-k8s-history:admin temporal-admin-k8s:admin
 
 juju relate temporal-k8s-matching:db postgresql-k8s:database
 juju relate temporal-k8s-matching:visibility postgresql-k8s:database
-juju relate temporal-k8s-matching:admin temporal-admin-k8s:admin
 
 juju relate temporal-k8s-worker:db postgresql-k8s:database
 juju relate temporal-k8s-worker:visibility postgresql-k8s:database
-juju relate temporal-k8s-worker:admin temporal-admin-k8s:admin
 ```
 
 Once deployed, you can run `juju status --watch 1s` to watch the status of your

--- a/documentation/how-to/upgrade-server.md
+++ b/documentation/how-to/upgrade-server.md
@@ -28,6 +28,9 @@ The Temporal K8s charms facilitate server upgrades in the following way:
 
    ```bash
    juju refresh temporal-admin-k8s --revision=<your_revision + 1>
+
+   # The schema setup action must be run before updating the Temporal K8s charm
+   juju run temporal-admin-k8s/leader setup-schema
    ```
 
    This will ensure that your database schema is updated if any updates are

--- a/templates/dynamic_config.jinja
+++ b/templates/dynamic_config.jinja
@@ -1,0 +1,15 @@
+{% set pairs = NAMESPACE_RPS_LIMIT.split('|') %}
+{%- if GLOBAL_RPS_LIMIT or NAMESPACE_RPS_LIMIT %}
+frontend.namespacerps:
+{%- if GLOBAL_RPS_LIMIT %}
+  - value: {{ GLOBAL_RPS_LIMIT }}
+{%- endif %}
+{%- if NAMESPACE_RPS_LIMIT %}
+{% for pair in pairs %}
+{% set namespace, value = pair.split(':') %}
+  - value: {{ value }}
+    constraints:
+      namespace: "{{ namespace }}"
+{% endfor %}
+{%- endif %}
+{%- endif %}

--- a/templates/dynamic_config.jinja
+++ b/templates/dynamic_config.jinja
@@ -2,14 +2,14 @@
 {%- if GLOBAL_RPS_LIMIT or NAMESPACE_RPS_LIMIT %}
 frontend.namespacerps:
 {%- if GLOBAL_RPS_LIMIT %}
-  - value: {{ GLOBAL_RPS_LIMIT }}
+- value: {{ GLOBAL_RPS_LIMIT }}
 {%- endif %}
 {%- if NAMESPACE_RPS_LIMIT %}
 {% for pair in pairs %}
 {% set namespace, value = pair.split(':') %}
-  - value: {{ value }}
-    constraints:
-      namespace: "{{ namespace }}"
+- value: {{ value }}
+  constraints:
+    namespace: "{{ namespace }}"
 {% endfor %}
 {%- endif %}
 {%- endif %}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -28,7 +28,12 @@ async def deploy(ops_test: OpsTest):
 
     # Deploy temporal server, temporal admin and postgresql charms.
     asyncio.gather(
-        ops_test.model.deploy(charm, resources=resources, application_name=APP_NAME, config={"num-history-shards": 1}),
+        ops_test.model.deploy(
+            charm,
+            resources=resources,
+            application_name=APP_NAME,
+            config={"num-history-shards": 1, "global-rps-limit": 100, "namespace-rps-limit": "default:50|test:40"},
+        ),
         ops_test.model.deploy(APP_NAME_ADMIN, channel="edge"),
         ops_test.model.deploy(APP_NAME_UI, channel="edge"),
         ops_test.model.deploy("postgresql-k8s", channel="14/stable", trust=True),

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -68,7 +68,6 @@ async def deploy(ops_test: OpsTest):
             if service != "temporal-k8s":
                 await ops_test.model.integrate(f"{service}:db", "postgresql-k8s:database")
                 await ops_test.model.integrate(f"{service}:visibility", "postgresql-k8s:database")
-                await ops_test.model.integrate(f"{service}:admin", f"{APP_NAME_ADMIN}:admin")
 
         await ops_test.model.wait_for_idle(apps=ALL_SERVICES, status="active", raise_on_blocked=False, timeout=1800)
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -8,6 +8,7 @@
 
 # pylint:disable=protected-access,too-many-public-methods
 
+from textwrap import dedent
 from unittest import TestCase, mock
 
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
@@ -570,24 +571,27 @@ class TestCharm(TestCase):
 
     def test_rendering(self):
         """The dynamic config gets rendered correctly."""
-        expected_output = """frontend.namespacerps:
-  - value: 500
+        expected_output = dedent(
+            """
+        frontend.namespacerps:
+        - value: 500
 
 
-  - value: 50
-    constraints:
-      namespace: "namespaceA"
+        - value: 50
+          constraints:
+            namespace: "namespaceA"
 
 
-  - value: 100
-    constraints:
-      namespace: "namespaceB"
+        - value: 100
+          constraints:
+            namespace: "namespaceB"
 
 
-  - value: 200
-    constraints:
-      namespace: "namespaceC"
+        - value: 200
+          constraints:
+            namespace: "namespaceC"
         """
+        ).strip()
 
         dynamic_context = {
             "GLOBAL_RPS_LIMIT": 500,
@@ -595,7 +599,7 @@ class TestCharm(TestCase):
         }
 
         dynamic_config = render("dynamic_config.jinja", dynamic_context).strip()
-        self.assertEqual(dynamic_config.strip(), expected_output.strip())
+        self.assertEqual(dedent(dynamic_config).strip(), expected_output)
 
 
 def simulate_lifecycle(harness):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -8,15 +8,13 @@
 
 # pylint:disable=protected-access,too-many-public-methods
 
-import json
 from unittest import TestCase, mock
 
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
 from ops.pebble import CheckStatus
 from ops.testing import Harness
 
-from charm import TemporalK8SCharm
-from state import State
+from charm import TemporalK8SCharm, render
 
 SERVER_PORT = "7233"
 mock_incomplete_pebble_plan = {"services": {"temporal": {"override": "replace"}}}
@@ -570,6 +568,35 @@ class TestCharm(TestCase):
         plan = harness.get_container_pebble_plan("temporal").to_dict()
         assert plan is not None
 
+    def test_rendering(self):
+        """The dynamic config gets rendered correctly."""
+        expected_output = """frontend.namespacerps:
+  - value: 500
+
+
+  - value: 50
+    constraints:
+      namespace: "namespaceA"
+
+
+  - value: 100
+    constraints:
+      namespace: "namespaceB"
+
+
+  - value: 200
+    constraints:
+      namespace: "namespaceC"
+        """
+
+        dynamic_context = {
+            "GLOBAL_RPS_LIMIT": 500,
+            "NAMESPACE_RPS_LIMIT": "namespaceA:50|namespaceB:100|namespaceC:200",
+        }
+
+        dynamic_config = render("dynamic_config.jinja", dynamic_context).strip()
+        self.assertEqual(dynamic_config.strip(), expected_output.strip())
+
 
 def simulate_lifecycle(harness):
     """Simulate a healthy charm life-cycle.
@@ -709,61 +736,3 @@ def s3_provider_databag():
         "region": "region",
         "s3-uri-style": "path",
     }
-
-
-class TestState(TestCase):
-    """Unit tests for state.
-
-    Attrs:
-        maxDiff: Specifies max difference shown by failed tests.
-    """
-
-    maxDiff = None
-
-    def test_get(self):
-        """It is possible to retrieve attributes from the state."""
-        state = make_state({"foo": json.dumps("bar")})
-        self.assertEqual(state.foo, "bar")
-        self.assertIsNone(state.bad)
-
-    def test_set(self):
-        """It is possible to set attributes in the state."""
-        data = {"foo": json.dumps("bar")}
-        state = make_state(data)
-        state.foo = 42
-        state.list = [1, 2, 3]
-        self.assertEqual(state.foo, 42)
-        self.assertEqual(state.list, [1, 2, 3])
-        self.assertEqual(data, {"foo": "42", "list": "[1, 2, 3]"})
-
-    def test_del(self):
-        """It is possible to unset attributes in the state."""
-        data = {"foo": json.dumps("bar"), "answer": json.dumps(42)}
-        state = make_state(data)
-        del state.foo
-        self.assertIsNone(state.foo)
-        self.assertEqual(data, {"answer": "42"})
-        # Deleting a name that is not set does not error.
-        del state.foo
-
-    def test_is_ready(self):
-        """The state is not ready when it is not possible to get relations."""
-        state = make_state({})
-        self.assertTrue(state.is_ready())
-
-        state = State("myapp", lambda: None)
-        self.assertFalse(state.is_ready())
-
-
-def make_state(data):
-    """Create state object.
-
-    Args:
-        data: Data to be included in state.
-
-    Returns:
-        State object with data.
-    """
-    app = "myapp"
-    rel = type("Rel", (), {"data": {app: data}})()
-    return State(app, lambda: rel)

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -1,0 +1,70 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+#
+# Learn more about testing at: https://juju.is/docs/sdk/testing
+
+
+"""State unit tests."""
+
+import json
+from unittest import TestCase
+
+from state import State
+
+
+class TestState(TestCase):
+    """Unit tests for state.
+
+    Attrs:
+        maxDiff: Specifies max difference shown by failed tests.
+    """
+
+    maxDiff = None
+
+    def test_get(self):
+        """It is possible to retrieve attributes from the state."""
+        state = make_state({"foo": json.dumps("bar")})
+        self.assertEqual(state.foo, "bar")
+        self.assertIsNone(state.bad)
+
+    def test_set(self):
+        """It is possible to set attributes in the state."""
+        data = {"foo": json.dumps("bar")}
+        state = make_state(data)
+        state.foo = 42
+        state.list = [1, 2, 3]
+        self.assertEqual(state.foo, 42)
+        self.assertEqual(state.list, [1, 2, 3])
+        self.assertEqual(data, {"foo": "42", "list": "[1, 2, 3]"})
+
+    def test_del(self):
+        """It is possible to unset attributes in the state."""
+        data = {"foo": json.dumps("bar"), "answer": json.dumps(42)}
+        state = make_state(data)
+        del state.foo
+        self.assertIsNone(state.foo)
+        self.assertEqual(data, {"answer": "42"})
+        # Deleting a name that is not set does not error.
+        del state.foo
+
+    def test_is_ready(self):
+        """The state is not ready when it is not possible to get relations."""
+        state = make_state({})
+        self.assertTrue(state.is_ready())
+
+        state = State("myapp", lambda: None)
+        self.assertFalse(state.is_ready())
+
+
+def make_state(data):
+    """Create state object.
+
+    Args:
+        data: Data to be included in state.
+
+    Returns:
+        State object with data.
+    """
+    app = "myapp"
+    rel = type("Rel", (), {"data": {app: data}})()
+    return State(app, lambda: rel)


### PR DESCRIPTION
This PR adds the following:
- Configurations for enabling rate limits by namespace as outlined [here](https://community.temporal.io/t/rate-limiting-by-namespace/1335). This should be done on a per-namespace basis, but I've also opened an issue to enable wildcard rule definitions [here](https://github.com/temporalio/temporal/issues/6237).
- Remove the need for an admin relation is the service is not `frontend`, as the admin charm only needs to be related to once for schema setup.
- Updates the relevant docs for the changes introduced in [this PR](https://github.com/canonical/temporal-admin-k8s-operator/pull/15).

Note: the libraries will not be updated in this PR as the update of the Loki library seems to deprecate the interface we are using, so a separate PR for this is in order.