### PR TITLE
chore: update to ops 2.16.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Jinja2==3.1.1
-ops==2.2.0
+ops==2.16.1
 async-timeout==4.0.3
 pydantic<2.0
 boto3==1.34.31

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -196,6 +196,14 @@ class TestCharm(TestCase):
                     "on-check-failure": {"up": "ignore"},
                 },
             },
+            "checks": {
+                "up": {
+                    "exec": {"command": "tctl --address=temporal-k8s:7236 cluster health"},
+                    "level": "alive",
+                    "override": "replace",
+                    "period": "300s",
+                }
+            },
         }
         got_plan = harness.get_container_pebble_plan("temporal").to_dict()
         self.assertEqual(got_plan, want_plan)
@@ -278,6 +286,14 @@ class TestCharm(TestCase):
                     "on-check-failure": {"up": "ignore"},
                 },
             },
+            "checks": {
+                "up": {
+                    "exec": {"command": "tctl --address=temporal-k8s:7236 cluster health"},
+                    "level": "alive",
+                    "override": "replace",
+                    "period": "300s",
+                }
+            },
         }
         got_plan = harness.get_container_pebble_plan("temporal").to_dict()
         self.assertEqual(got_plan, want_plan)
@@ -329,6 +345,14 @@ class TestCharm(TestCase):
                     },
                     "on-check-failure": {"up": "ignore"},
                 },
+            },
+            "checks": {
+                "up": {
+                    "exec": {"command": "tctl --address=temporal-k8s:7236 cluster health"},
+                    "level": "alive",
+                    "override": "replace",
+                    "period": "300s",
+                }
             },
         }
         got_plan = harness.get_container_pebble_plan("temporal").to_dict()
@@ -498,6 +522,14 @@ class TestCharm(TestCase):
                         "OFGA_API_PORT": harness.charm._state.openfga["port"],
                     },
                     "on-check-failure": {"up": "ignore"},
+                }
+            },
+            "checks": {
+                "up": {
+                    "exec": {"command": "tctl --address=temporal-k8s:7236 cluster health"},
+                    "level": "alive",
+                    "override": "replace",
+                    "period": "300s",
                 }
             },
         }


### PR DESCRIPTION
This PR bumps ops to the latest version (2.16.1) and adjusts the tests to match, which is only that the Pebble plan that Harness returns includes the checks as well as the services.

ops 2.16 should be compatible with ops 2.2, so there should be no runtime behaviour changes.