### PR TITLE
CSS-10692: Add alert rules

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,16 @@ on:
   pull_request:
 
 jobs:
+  alertmanager-rules-lint:
+    name: Alertmanager Rules Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Prometheus
+        run: sudo snap install prometheus
+      - name: Run promtool checks on Prometheus alert definitions
+        run: promtool check rules $(find "$PWD" -name "*_rules.yaml")
   unit-tests:
     uses: canonical/operator-workflows/.github/workflows/test.yaml@main
     secrets: inherit

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -67,10 +67,10 @@ provides:
 containers:
   temporal:
     resource: temporal-server-image
-    # Included for simplicity in integration tests.
-    upstream-source: ghcr.io/canonical/temporal-server:latest
 
 resources:
   temporal-server-image:
     type: oci-image
     description: OCI image for Temporal
+    # Included for simplicity in integration tests.
+    upstream-source: ghcr.io/canonical/temporal-server:latest

--- a/src/grafana_dashboards/temporal-monitoring.json.tmpl
+++ b/src/grafana_dashboards/temporal-monitoring.json.tmpl
@@ -43,6 +43,43 @@
       "type": "row"
     },
     {
+      "datasource": {
+        "type": "loki",
+        "uid": "${prometheusds}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 101,
+      "options": {
+        "dedupStrategy": "exact",
+        "enableLogDetails": true,
+        "prettifyLogMessage": true,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": false,
+        "sortOrder": "Descending",
+        "wrapLogMessage": false
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${prometheusds}"
+          },
+          "editorMode": "builder",
+          "expr": "{juju_application=\"$juju_application\"}",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Server Logs",
+      "type": "logs"
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -228,6 +265,98 @@
       "yaxis": {
         "align": false
       }
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusds}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 101,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P2B9F25C311467308"
+          },
+          "editorMode": "code",
+          "expr": "sum by (namespace) (rate(service_authorization_latency_sum{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}[5m]))/sum by (namespace) (rate(service_authorization_latency_count{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}[5m]))",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Average Latency Per Authorization Request (Per 5 Minutes)",
+      "type": "timeseries"
     },
     {
       "aliasColors": {},
@@ -521,91 +650,6 @@
       "timeRegions": [],
       "timeShift": null,
       "title": "Activities",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${prometheusds}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "links": []
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 10,
-        "w": 6,
-        "x": 18,
-        "y": 10
-      },
-      "hiddenSeries": false,
-      "id": 9,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true,
-        "dataLinks": []
-      },
-      "percentage": false,
-      "pluginVersion": "8.3.4",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Pollers",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1713,7 +1757,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Workflow Completion Overview",
+      "title": "Workflow Completion Overview (Per 5 Minutes)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1803,7 +1847,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Workflow Success By Namespace",
+      "title": "Workflow Success By Namespace (Per 5 Minutes)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1893,7 +1937,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Workflow Failed By Namespace",
+      "title": "Workflow Failed By Namespace  (Per 5 Minutes)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1983,7 +2027,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Workflow Timedout By Namespace",
+      "title": "Workflow Timedout By Namespace (Per 5 Minutes)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -2073,7 +2117,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Workflow Terminate By Namespace",
+      "title": "Workflow Terminate By Namespace (Per 5 Minutes)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -2163,103 +2207,13 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Workflow Cancelled By Namespace",
+      "title": "Workflow Cancelled By Namespace (Per 5 Minutes)",
       "tooltip": {
         "shared": true,
         "sort": 0,
         "value_type": "individual"
       },
       "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${prometheusds}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 72
-      },
-      "hiddenSeries": false,
-      "id": 100,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
-      "percentage": false,
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum by (namespace) (workflow_success{juju_application=\"$juju_application\",juju_model=\"$juju_model\",juju_model_uuid=\"$juju_model_uuid\",juju_unit=\"$juju_unit\",operation=\"CompletionStats\"})",
-          "interval": "",
-          "legendFormat": "{{ temporal_namespace }}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Number of Successful Workflow Executions",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "bargauge",
       "xaxis": {
         "buckets": null,
         "mode": "time",

--- a/src/prometheus_alert_rules/temporal_rules.yaml
+++ b/src/prometheus_alert_rules/temporal_rules.yaml
@@ -1,0 +1,22 @@
+groups:
+
+- name: TemporalK8s
+
+  rules:
+    - alert: TemporalServerDown
+      expr: '100 - (sum(rate(service_errors[2m]) or on() vector(0)) / sum(rate(service_requests[2m])) * 100) == 0'
+      for: 0m
+      labels:
+        severity: critical
+      annotations:
+        summary: Temporal server is down (instance {{ $labels.instance }})
+        description: "Temporal instance is down\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+
+    - alert: TemporalDBDown
+      expr: '100 - (sum (rate(persistence_errors[2m]) OR on() vector(0)) /sum (rate(persistence_requests[2m])) * 100) == 0'
+      for: 0m
+      labels:
+        severity: critical
+      annotations:
+        summary: Temporal down (instance {{ $labels.instance }})
+        description: "Temporal instance is down\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"

--- a/src/prometheus_alert_rules/temporal_rules.yaml
+++ b/src/prometheus_alert_rules/temporal_rules.yaml
@@ -15,13 +15,13 @@ groups:
         severity: critical
       annotations:
         summary: Temporal server is down (instance {{ $labels.instance }})
-        description: "Temporal instance is down\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+        description: "Temporal server instance is down\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
 
-    - alert: TemporalDBDown
+    - alert: TemporalDatabaseDown
       expr: '100 - (sum (rate(persistence_errors[2m]) OR on() vector(0)) /sum (rate(persistence_requests[2m])) * 100) == 0'
       for: 0m
       labels:
         severity: critical
       annotations:
-        summary: Temporal down (instance {{ $labels.instance }})
-        description: "Temporal instance is down\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+        summary: Temporal database is down (instance {{ $labels.instance }})
+        description: "Temporal database instance is down\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"

--- a/src/prometheus_alert_rules/temporal_rules.yaml
+++ b/src/prometheus_alert_rules/temporal_rules.yaml
@@ -1,3 +1,8 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+#
+# Learn more at: https://juju.is/docs/sdk
+
 groups:
 
 - name: TemporalK8s

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -36,7 +36,7 @@ async def charm_fixture(request: FixtureRequest, ops_test: OpsTest) -> str | Pat
 @pytest_asyncio.fixture(name="deploy", scope="module")
 async def deploy(ops_test: OpsTest, charm: str):
     """The app is up and running."""
-    resources = {"temporal-server-image": METADATA["containers"]["temporal"]["upstream-source"]}
+    resources = {"temporal-server-image": METADATA["resources"]["temporal-server-image"]["upstream-source"]}
 
     # Deploy temporal server, temporal admin and postgresql charms.
     asyncio.gather(

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -125,7 +125,7 @@ async def simulate_charm_crash(ops_test: OpsTest):
     await ops_test.model.block_until(lambda: APP_NAME not in ops_test.model.applications)
 
     charm = await ops_test.build_charm(".")
-    resources = {"temporal-server-image": METADATA["containers"]["temporal"]["upstream-source"]}
+    resources = {"temporal-server-image": METADATA["resources"]["temporal-server-image"]["upstream-source"]}
 
     # Deploy temporal server, temporal admin and postgresql charms.
     await ops_test.model.deploy(

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 async def deploy(ops_test: OpsTest):
     """The app is up and running."""
     charm = await ops_test.build_charm(".")
-    resources = {"temporal-server-image": METADATA["containers"]["temporal"]["upstream-source"]}
+    resources = {"temporal-server-image": METADATA["resources"]["temporal-server-image"]["upstream-source"]}
 
     await ops_test.model.set_config({"update-status-hook-interval": "1m"})
 

--- a/tests/integration/test_upgrades.py
+++ b/tests/integration/test_upgrades.py
@@ -59,7 +59,7 @@ class TestUpgrade:
     async def test_upgrade(self, ops_test: OpsTest):
         """Builds the current charm and refreshes the current deployment."""
         charm = await ops_test.build_charm(".")
-        resources = {"temporal-server-image": METADATA["containers"]["temporal"]["upstream-source"]}
+        resources = {"temporal-server-image": METADATA["resources"]["temporal-server-image"]["upstream-source"]}
 
         await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", raise_on_blocked=False, timeout=600)
 

--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,7 @@ commands =
     isort --check-only --diff {[vars]src_path} {[vars]tst_path}
     black --check --diff {[vars]src_path} {[vars]tst_path}
     mypy {[vars]all_path} --ignore-missing-imports --follow-imports=skip --install-types --non-interactive
-    pylint {[vars]all_path} --disable=E0401,W1203,W0613,W0718,R0903,W1514,C0103,R0913,C0301,W0212,R0902,C0104,W0640,R0801,W0511,R0914,R0912,W0719
+    pylint {[vars]all_path} --disable=E0401,W1203,W0613,W0718,R0903,W1514,C0103,R0913,C0301,W0212,R0902,C0104,W0640,R0801,W0511,R0914,R0912,W0719,R0917
 
 [testenv:unit]
 description = Run tests


### PR DESCRIPTION
This PR:
- Adds alert rules based on the prometheus metrics to alert on the Temporal cluster or database being down.
- Modifies the grafana dashboard by adding a couple of new panels and removing one redundant one.
- Updates the loki library.

I've attached screenshots of the two panels added to the dashboard.

![Screenshot from 2024-09-26 13-24-44](https://github.com/user-attachments/assets/6c3b4d81-5fa1-4da6-8b0d-e5661987d1f5)

![image](https://github.com/user-attachments/assets/ff972dc7-7799-4152-9cce-85ba12853b13)
