### PR TITLE
Update alertmanager rules and logs panel

### DIFF
--- a/src/grafana_dashboards/temporal-monitoring.json.tmpl
+++ b/src/grafana_dashboards/temporal-monitoring.json.tmpl
@@ -59,7 +59,7 @@
         "enableLogDetails": true,
         "prettifyLogMessage": true,
         "showCommonLabels": false,
-        "showLabels": false,
+        "showLabels": true,
         "showTime": false,
         "sortOrder": "Descending",
         "wrapLogMessage": false
@@ -68,10 +68,10 @@
         {
           "datasource": {
             "type": "loki",
-            "uid": "${prometheusds}"
+            "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "{juju_application=\"$juju_application\"}",
+          "expr": "{juju_application=\"temporal-k8s\"}",
           "queryType": "range",
           "refId": "A"
         }
@@ -346,7 +346,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P2B9F25C311467308"
+            "uid": "${prometheusds}"
           },
           "editorMode": "code",
           "expr": "sum by (namespace) (rate(service_authorization_latency_sum{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}[5m]))/sum by (namespace) (rate(service_authorization_latency_count{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}[5m]))",

--- a/src/prometheus_alert_rules/temporal_rules.yaml
+++ b/src/prometheus_alert_rules/temporal_rules.yaml
@@ -9,7 +9,7 @@ groups:
 
   rules:
     - alert: TemporalServerDown
-      expr: '100 - (sum(rate(service_errors[2m]) or on() vector(0)) / sum(rate(service_requests[2m])) * 100) == 0'
+      expr: '100 - (sum(rate(service_errors[2m]) or on() vector(0)) / sum(rate(service_requests[2m])) * 100) < 10'
       for: 0m
       labels:
         severity: critical
@@ -18,7 +18,7 @@ groups:
         description: "Temporal server instance is down\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
 
     - alert: TemporalDatabaseDown
-      expr: '100 - (sum (rate(persistence_errors[2m]) OR on() vector(0)) /sum (rate(persistence_requests[2m])) * 100) == 0'
+      expr: '100 - (sum (rate(persistence_errors[2m]) OR on() vector(0)) /sum (rate(persistence_requests[2m])) * 100) < 10'
       for: 0m
       labels:
         severity: critical


### PR DESCRIPTION
After testing the alert rules, it seems the persistence availability never quite goes to 0 even when the relation is broken between the temporal-k8s and postgres charms. I've updated the alert rules to signal that the service is down when availability goes below 10%.