### PR TITLE
Fix DB TLS flag bug

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -2,6 +2,7 @@ header:
   license:
     spdx-id: Apache-2.0
     copyright-owner: Canonical Ltd.
+    copyright-year: 2024
     content: |
       Copyright [year] [owner]
       See LICENSE file for licensing details.

--- a/config.yaml
+++ b/config.yaml
@@ -121,6 +121,6 @@ options:
     type: string
 
   db-tls-enabled:
-    description: Whether or not TLS is enabled on the database.
+    description: (Deprecated as of postgresql-k8s revision 462) Whether or not TLS is enabled on the database.
     default: False
     type: boolean

--- a/config.yaml
+++ b/config.yaml
@@ -121,6 +121,6 @@ options:
     type: string
 
   db-tls-enabled:
-    description: Where TLS is enabled on the database.
+    description: Whether or not TLS is enabled on the database.
     default: False
     type: boolean

--- a/src/relations/postgresql.py
+++ b/src/relations/postgresql.py
@@ -120,7 +120,7 @@ class Postgresql(framework.Object):
                 "port": primary_endpoint[1],
                 "password": relation_data.get("password"),
                 "user": relation_data.get("username"),
-                "tls": relation_data.get("tls") == "True" or self.charm.config["db-tls-enabled"],
+                "tls": relation_data.get("tls") == "True",
             }
 
             if None in (db_conn["user"], db_conn["password"]):

--- a/src/relations/postgresql.py
+++ b/src/relations/postgresql.py
@@ -120,7 +120,7 @@ class Postgresql(framework.Object):
                 "port": primary_endpoint[1],
                 "password": relation_data.get("password"),
                 "user": relation_data.get("username"),
-                "tls": relation_data.get("tls") or self.charm.config["db-tls-enabled"],
+                "tls": relation_data.get("tls") == True or self.charm.config["db-tls-enabled"],
             }
 
             if None in (db_conn["user"], db_conn["password"]):

--- a/src/relations/postgresql.py
+++ b/src/relations/postgresql.py
@@ -120,7 +120,7 @@ class Postgresql(framework.Object):
                 "port": primary_endpoint[1],
                 "password": relation_data.get("password"),
                 "user": relation_data.get("username"),
-                "tls": relation_data.get("tls") == True or self.charm.config["db-tls-enabled"],
+                "tls": relation_data.get("tls") == "True" or self.charm.config["db-tls-enabled"],
             }
 
             if None in (db_conn["user"], db_conn["password"]):

--- a/src/relations/postgresql.py
+++ b/src/relations/postgresql.py
@@ -120,7 +120,7 @@ class Postgresql(framework.Object):
                 "port": primary_endpoint[1],
                 "password": relation_data.get("password"),
                 "user": relation_data.get("username"),
-                "tls": relation_data.get("tls") == "True",
+                "tls": relation_data.get("tls") == "True" or self.charm.config["db-tls-enabled"],
             }
 
             if None in (db_conn["user"], db_conn["password"]):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -62,10 +62,10 @@ async def deploy(ops_test: OpsTest, charm: str):
             apps=["postgresql-k8s", "self-signed-certificates"], status="active", raise_on_blocked=False, timeout=1200
         )
 
-        # await ops_test.model.integrate("self-signed-certificates", "postgresql-k8s")
-        # await ops_test.model.wait_for_idle(
-        #     apps=["postgresql-k8s", "self-signed-certificates"], status="active", raise_on_blocked=False, timeout=1200
-        # )
+        await ops_test.model.integrate("self-signed-certificates", "postgresql-k8s")
+        await ops_test.model.wait_for_idle(
+            apps=["postgresql-k8s", "self-signed-certificates"], status="active", raise_on_blocked=False, timeout=1200
+        )
         await ops_test.model.wait_for_idle(
             apps=[APP_NAME, APP_NAME_ADMIN, APP_NAME_UI], status="blocked", raise_on_blocked=False, timeout=600
         )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -47,7 +47,7 @@ async def deploy(ops_test: OpsTest, charm: str):
             config={
                 "num-history-shards": 1,
                 "global-rps-limit": 100,
-                "db-tls-enabled": True,
+                "db-tls-enabled": False,
                 "namespace-rps-limit": "default:50|test:40",
             },
         ),
@@ -62,10 +62,10 @@ async def deploy(ops_test: OpsTest, charm: str):
             apps=["postgresql-k8s", "self-signed-certificates"], status="active", raise_on_blocked=False, timeout=1200
         )
 
-        await ops_test.model.integrate("self-signed-certificates", "postgresql-k8s")
-        await ops_test.model.wait_for_idle(
-            apps=["postgresql-k8s", "self-signed-certificates"], status="active", raise_on_blocked=False, timeout=1200
-        )
+        # await ops_test.model.integrate("self-signed-certificates", "postgresql-k8s")
+        # await ops_test.model.wait_for_idle(
+        #     apps=["postgresql-k8s", "self-signed-certificates"], status="active", raise_on_blocked=False, timeout=1200
+        # )
         await ops_test.model.wait_for_idle(
             apps=[APP_NAME, APP_NAME_ADMIN, APP_NAME_UI], status="blocked", raise_on_blocked=False, timeout=600
         )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -47,7 +47,6 @@ async def deploy(ops_test: OpsTest, charm: str):
             config={
                 "num-history-shards": 1,
                 "global-rps-limit": 100,
-                "db-tls-enabled": False,
                 "namespace-rps-limit": "default:50|test:40",
             },
         ),

--- a/tests/integration/test_upgrades.py
+++ b/tests/integration/test_upgrades.py
@@ -32,7 +32,7 @@ async def deploy(ops_test: OpsTest):
     await ops_test.model.deploy(APP_NAME, channel="edge", config={"num-history-shards": 1})
     await ops_test.model.deploy(APP_NAME_ADMIN, channel="edge")
     await ops_test.model.deploy(APP_NAME_UI, channel="edge")
-    await ops_test.model.deploy("postgresql-k8s", channel="14/stable", trust=True)
+    await ops_test.model.deploy("postgresql-k8s", channel="14/stable", trust=True, revision=381)
 
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(


### PR DESCRIPTION
The latest release of the postgresql-k8s charm (revision 462) unveiled a bug in the way we are consuming the tls flag from the relation databag with the postgresql-k8s charm. This PR fixes the issue.

There is also a legacy configuration value that was in place to accommodate for the missing tls flag in the relation databag at the time. I will be keeping this in place for a while for backwards compatibility before deprecating it.