### PR TITLE
Run integration tests against 3.6/stable juju

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -14,6 +14,6 @@ jobs:
     with:
       channel: 1.28-strict/stable
       modules: '["test_charm.py", "test_auth.py", "test_scaling.py", "test_server_upgrade.py", "test_upgrades.py"]'
-      juju-channel: 3.4/stable
+      juju-channel: 3.6/stable
       self-hosted-runner: false
       microk8s-addons: "dns ingress rbac storage metallb:10.15.119.2-10.15.119.4 registry"


### PR DESCRIPTION
## Description
We would like to start testing all temporal charms against the LTS juju version (3.6/stable)

## Merging instructions

The preferred way of merging:
- [ ] Merge
- [x] Squash and Merge
- [ ] Rebase and Merge