### PR TITLE
ci: add a PR template that should be the standard for all WF repos

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,30 +1,22 @@
 ## Description
+<!-- Summary of the changes in this PR -->
 
-The what and why - include a summary of the change, describe what it does, and include relevant motivation and context.
+<!-- Reference the issue this PR addresses (e.g., Closes #123) -->
 
-Fixes _JIRA/GitHub issue number_
+---
+## Testing instructions
+<!-- Steps to manually test the changes and the expected results, only if applicable -->
+<!-- Example:
+1. Build charm
+2. Configure X with abc value
+3. Integrate with Y charm
+-->
 
-## Engineering checklist
-_Check only items that apply_
+## Notes for Reviewers (optional)
+<!-- Any specific areas to focus on, known issues, or extra context -->
 
+---
+## Checklist (all that apply)
+- [ ] Unit tests added or updated
+- [ ] Integration tests added or updated
 - [ ] Documentation updated
-- [ ] Covered by unit tests
-- [ ] Covered by integration tests
-- [ ] Independent change*
-
- _* This is an independent change if it can be merged and released independently without any related service deployments._
-
-## Merging instructions
-
-The preferred way of merging:
-- [ ] Merge
-- [ ] Squash and Merge
-- [ ] Rebase and Merge
-
-## Test instructions
-
-_(optional)_ Describe any non-standard test instructions and configuration settings. Delete this section if not applicable.
-
-## Notes for code reviewers
-
-_(optional)_ Mention any relevant information for code reviewers. Delete this section if not applicable.


### PR DESCRIPTION
This minimal PR template requests relevant information such as description, manual testing instructions (if applicable), notes for reviewers, and what issue the PR is solving, as well as a small checklist for ensuring contributors are reminded of adding unit/integration tests and document updates, if needed.


## Engineering checklist
_Check only items that apply_

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Independent change*

 _* This is an independent change if it can be merged and released independently without any related service deployments._

## Merging instructions

The preferred way of merging:
- [ ] Merge
- [x] Squash and Merge
- [ ] Rebase and Merge
