### PR TITLE
chore: add epic number to jira sync automation config

### DIFF
--- a/.github/.jira_sync_config.yaml
+++ b/.github/.jira_sync_config.yaml
@@ -22,6 +22,9 @@ settings:
   # (Optional) (Default: true) Synchronize comments from GitHub to Jira
   sync_comments: false
 
+  # (Optional) (Default: None) Parent Epic key to link the issue to
+  epic_key: "WF-63"
+
   # (Optional) Dictionary mapping GitHub issue labels to Jira issue types.
   # If label on the issue is not in specified list, this issue will be created as a Bug
   label_mapping:


### PR DESCRIPTION


## Description
<!-- Summary of the changes in this PR -->
By adding an epic to the configuration, we guarantee that all synced issues are also automatically added to said Jira epic.
<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->
N/A
## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->
N/A
---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
