### PR TITLE
fix: postgresql 16 compatibility

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -150,3 +150,12 @@ options:
       This configuration option is only used when the charm is integrated with the frontend-certificates relation.
     default: ""
     type: string
+
+  bootstrap-db-extra-user-roles:
+    description: |
+        Enumeration of extra database roles that should be requested to the 
+        database. This cannot be changed after deployment.
+
+        This should be set to `charmed_admin` for postgresql version 16.
+    default: admin
+    type: string

--- a/src/charm.py
+++ b/src/charm.py
@@ -142,12 +142,17 @@ class TemporalK8SCharm(CharmBase):
         self.framework.observe(self.on.update_status, self._on_update_status)
 
         # Handle postgresql relation.
-        self.db = DatabaseRequires(self, relation_name="db", database_name=DB_NAME, extra_user_roles="admin")
+        self.db = DatabaseRequires(
+            self,
+            relation_name="db",
+            database_name=DB_NAME,
+            extra_user_roles=self.config["bootstrap-db-extra-user-roles"],
+        )
         self.visibility = DatabaseRequires(
             self,
             relation_name="visibility",
             database_name=VISIBILITY_DB_NAME,
-            extra_user_roles="admin",
+            extra_user_roles=self.config["bootstrap-db-extra-user-roles"],
         )
         self.postgresql = Postgresql(self)
 


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->

Charmed Postgresql version 16 introduced breaking changes in the way database roles are used: the `admin` role, required by temporal charm, was renamed to `charmed_admin`. Currently there's no way to programmatically figure out the correct role, and the recommended fix is to include a configuration parameter for the role name in the client charms.

This PR allows the user to configure which `extra-user-roles` Temporal should request. This parameter can be set only during deployment, changing it afterwards has no effect.

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->

1. Build charm
2. deploy it setting the new parameter: 
```
juju deploy 
  ./temporal-k8s_ubuntu-22.04-amd64.charm temporal-k8s \
  --resource temporal-server-image=ghcr.io/canonical/temporal-server:latest \
  --config bootstrap-db-extra-user-roles=charmed_admin
```
3. Integrate with postgresql charm version >=16
