### PR TITLE
ci: add missing runners input in JSON format

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,3 +22,4 @@ jobs:
       release-channel: "1.23/edge"
       charm-path: "."
       charmcraft-channel: "3.x/candidate"
+      runners: '["ubuntu-latest"]'


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

This set the runner to use ubuntu-latest by passing a valid JSON to the workflow.

Otherwise, the CI fails with:

```
Error when evaluating 'strategy' for job 'build'. canonical/observability/.github/workflows/_charm-release.yaml@v1 (Line: 44, Col: 17): Error from function 'fromJSON': Unexpected symbol: 'ubuntu-latest'. Located at line 1 position 1 within JSON., canonical/observability/.github/workflows/_charm-release.yaml@v1 (Line: 44, Col: 17): Unexpected value ''
```

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
