### PR TITLE
[WF-92] Enable static code analysis (TIOBE) scans

### DIFF
--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -1,44 +1,14 @@
+name: Tiobe TiCS Analysis
+
 on:
-  workflow_dispatch:
-  schedule:
-    - cron: '17 2 * * 1'  # every Monday 02:17 UTC
+    workflow_dispatch:
+    schedule:
+    - cron: "17 2 * * 1"  # Runs at 2:17 UTC every Monday
 
 jobs:
-  build:
-    runs-on: [self-hosted, linux, amd64, tiobe, jammy]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.12
-
-      - name: Install deps
-        run: |
-          pip install tox pylint flake8 coverage
-          
-      - name: Run unit & coverage
-        run: |
-          COVERAGE_FILE=.coverage tox -e unit
-
-      - name: Generate coverage.xml
-        run: |
-          coverage xml -o coverage.xml --omit '*/lib/*'
-          
-      - name: Prep coverage for TICS
-        run: |
-          mkdir -p .cover
-          mv coverage.xml .cover/coverage.xml
-          
-      - name: TICS analysis
-        uses: tiobe/tics-github-action@v3
-        with:
-          mode: qserver
-          project: temporal-k8s-operator
-          branchdir: .
-          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
-          ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
-          installTics: true
+    tics:
+        name: TiCs
+        uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@main
+        with: 
+            coverage-folder: ".cover"
+        secrets: inherit

--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -1,46 +1,13 @@
-name: TICS run self-hosted test (github-action)
+name: Tiobe TiCS Analysis
 
 on:
-  workflow_dispatch: # Allows manual triggering
-  schedule:
-    - cron: "17 2 * * 1" # Every Monday 2:17 AM UTC
+    pull_request:
+    workflow_dispatch:
+    schedule:
+    - cron: "17 2 * * 1"  # Runs at 2:17 UTC every Monday
 
 jobs:
-  build:
-    runs-on: [self-hosted, linux, amd64, tiobe, jammy]
-
-    steps:
-      - name: Checkout the project
-        uses: actions/checkout@v4
-
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.12
-
-      - name: Install dependencies
-        run: |
-          pip install tox
-          pip install pylint flake8 coverage
-
-      - name: Run tox tests to create coverage.xml
-        run: tox run -e unit
-
-      - name: Generate coverage.xml
-        run: |
-          coverage xml -o coverage.xml --omit="*/lib/*,*/external/*"
-
-      - name: Move results to necessary folder for TICS
-        run: |
-          mkdir -p .cover
-          mv coverage.xml .cover/coverage.xml
-
-      - name: Run TICS analysis with github-action
-        uses: tiobe/tics-github-action@v3
-        with:
-          mode: qserver
-          project: temporal-k8s-operator
-          branchdir: .
-          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
-          ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
-          installTics: true
+    tics:
+        name: TiCs
+        uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@main
+        secrets: inherit

--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -1,13 +1,40 @@
-name: Tiobe TiCS Analysis
-
 on:
-    pull_request:
-    workflow_dispatch:
-    schedule:
-    - cron: "17 2 * * 1"  # Runs at 2:17 UTC every Monday
+  workflow_dispatch:
+  schedule:
+    - cron: '17 2 * * 1'  # every Monday 02:17 UTC
 
 jobs:
-    tics:
-        name: TiCs
-        uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@main
-        secrets: inherit
+  build:
+    runs-on: [self-hosted, linux, amd64, tiobe, jammy]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+
+      - name: Install deps
+        run: |
+          pip install tox pylint flake8 coverage
+      - name: Run unit & coverage
+        run: |
+          tox -e unit
+      - name: Generate coverage.xml
+        run: |
+          coverage xml -o coverage.xml
+      - name: Prep coverage for TICS
+        run: |
+          mkdir -p .cover
+          mv coverage.xml .cover/coverage.xml
+      - name: TICS analysis
+        uses: tiobe/tics-github-action@v3
+        with:
+          mode: qserver
+          project: temporal-worker-k8s-operator
+          branchdir: .
+          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
+          ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
+          installTics: true

--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -1,0 +1,48 @@
+name: TICS run self-hosted test (github-action)
+
+on:
+  workflow_dispatch: # Allows manual triggering
+  #pull_request:
+  schedule:
+    - cron: "0 2 * * 1" # Every Monday 2:00 AM UTC
+
+jobs:
+  build:
+    runs-on: [self-hosted, linux, amd64, tiobe, jammy]
+
+    steps:
+      - name: Checkout the project
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+
+      - name: Install dependencies
+        run: |
+          pip install tox
+          pip install pylint flake8 coverage
+
+      - name: Run tox tests to create coverage.xml
+        run: tox run -e unit
+
+      - name: Generate coverage.xml
+        run: |
+          coverage xml -o coverage.xml
+
+      - name: Move results to necessary folder for TICS
+        run: |
+          mkdir -p .cover
+          mv coverage.xml .cover/coverage.xml
+
+      - name: Run TICS analysis with github-action
+        uses: tiobe/tics-github-action@v3
+        with:
+          mode: qserver
+          project: temporal-k8s-operator
+          branchdir: .
+          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
+          ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
+          installTics: true
+          filelist: .github/tics-filelist.txt

--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: tiobe/tics-github-action@v3
         with:
           mode: qserver
-          project: temporal-worker-k8s-operator
+          project: temporal-k8s-operator
           branchdir: .
           viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
           ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}

--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -2,9 +2,8 @@ name: TICS run self-hosted test (github-action)
 
 on:
   workflow_dispatch: # Allows manual triggering
-  #pull_request:
   schedule:
-    - cron: "0 2 * * 1" # Every Monday 2:00 AM UTC
+    - cron: "17 2 * * 1" # Every Monday 2:17 AM UTC
 
 jobs:
   build:
@@ -29,7 +28,7 @@ jobs:
 
       - name: Generate coverage.xml
         run: |
-          coverage xml -o coverage.xml
+          coverage xml -o coverage.xml --omit="*/lib/*,*/external/*"
 
       - name: Move results to necessary folder for TICS
         run: |
@@ -45,4 +44,3 @@ jobs:
           viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
           ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
           installTics: true
-          filelist: .github/tics-filelist.txt

--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -19,16 +19,20 @@ jobs:
       - name: Install deps
         run: |
           pip install tox pylint flake8 coverage
+          
       - name: Run unit & coverage
         run: |
-          tox -e unit
+          COVERAGE_FILE=.coverage tox -e unit
+
       - name: Generate coverage.xml
         run: |
-          coverage xml -o coverage.xml
+          coverage xml -o coverage.xml --omit '*/lib/*'
+          
       - name: Prep coverage for TICS
         run: |
           mkdir -p .cover
           mv coverage.xml .cover/coverage.xml
+          
       - name: TICS analysis
         uses: tiobe/tics-github-action@v3
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,10 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+[project]
+name = "temporal-k8s-operator"
+version = "0.0"
+
 [tool.bandit]
 exclude_dirs = ["/venv/"]
 [tool.bandit.assert_used]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,24 +1,6 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-[project]
-name = "temporal-k8s-operator-ci"  
-version = "0.0.0"
-requires-python = ">=3.10"
-
-[project.optional-dependencies]
-dev = [
-  "pylint",
-  "flake8",
-  "pytest",
-  "coverage"
-]
-
-[tool.bandit]
-exclude_dirs = ["/venv/"]
-[tool.bandit.assert_used]
-skips = ["*/*test.py", "*/test_*.py", "*tests/*.py"]
-
 # Testing tools configuration
 [tool.coverage.run]
 branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,19 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+[project]
+name = "temporal-k8s-operator-ci"  
+version = "0.0.0"
+requires-python = ">=3.10"
+
+[project.optional-dependencies]
+dev = [
+  "pylint",
+  "flake8",
+  "pytest",
+  "coverage"
+]
+
 [tool.bandit]
 exclude_dirs = ["/venv/"]
 [tool.bandit.assert_used]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,10 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+[tool.bandit]
+exclude_dirs = ["/venv/"]
+[tool.bandit.assert_used]
+skips = ["*/*test.py", "*/test_*.py", "*tests/*.py"]
 # Testing tools configuration
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
## Description
Added Static Code Analysis to the repo to run every Monday automatically or by manual trigger.

---
## Testing instructions
The workflow can be tested by manual trigger or by automated trigger at 2 UTC every Monday.

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
