### PR TITLE
[WF-92] Enable static code analysis (TIOBE) scans

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,6 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 [run]
 source = src
 omit =

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,8 @@
+[run]
+source = src
+omit =
+    lib/*
+
+[report]
+omit =
+    lib/*

--- a/.github/tics-filelist.txt
+++ b/.github/tics-filelist.txt
@@ -1,0 +1,2 @@
+src/
+tests/

--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: [self-hosted, linux, amd64, tiobe, jammy]
+    runs-on: [self-hosted, linux, amd64, tiobe, noble]
 
     steps:
       - name: Checkout the project

--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -20,6 +20,7 @@ jobs:
         with:
           mode: qserver
           project: temporal-k8s-operator
+          branch: track/1.23
           branchdir: .
           viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
           ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}

--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch: # Allows manual triggering
   pull_request:
   schedule:
-    - cron: "0 2 * * 6" # Every Saturday 2:00 AM UTC
+    - cron: "0 2 * * 1" # Every Monday 2:00 AM UTC
 
 jobs:
   build:

--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -1,27 +1,14 @@
 #Force github to re-register workflow
-name: TICS run self-hosted test (github-action)
+name: Tiobe TiCS Analysis
 
 on:
-  workflow_dispatch:  # allows manual trigger
+  workflow_dispatch:  # Manual trigger
   pull_request:
   schedule:
-    - cron: '0 4 * * 1'  # every Monday at 4 AM UTC
+    - cron: '0 4 * * 1'  # Every Monday at 4 AM UTC
 
 jobs:
-  run-tics-analysis:
-    runs-on: [self-hosted, amd64, tiobe, noble]
-
-    steps:
-      - name: Checkout the project
-        uses: actions/checkout@v4
-
-      - name: Run TICS analysis with github-action
-        uses: tiobe/tics-github-action@v3
-        with:
-          mode: qserver
-          project: temporal-k8s-operator
-          branchname: main
-          branchdir: .
-          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
-          ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
-          installTics: true
+  tics:
+    name: TiCS
+    uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@v1
+    secrets: inherit

--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -1,3 +1,4 @@
+#Force github to re-register workflow
 name: TICS run self-hosted test (github-action)
 
 on:

--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           mode: qserver
           project: temporal-k8s-operator
-          branchname: track/1.23
+          branchname: main
           branchdir: .
           viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
           ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}

--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   tics:
     name: TiCS Analysis
-    runs-on: [self-hosted, amd64, tiobe, noble]
+    runs-on: [self-hosted, linus, amd64, tiobe, jammy]
 
     steps:
       - name: Checkout the project

--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -2,6 +2,7 @@ name: TICS run self-hosted test (github-action)
 
 on:
   workflow_dispatch: # Allows manual triggering
+  pull_request:
   schedule:
     - cron: "0 2 * * 6" # Every Saturday 2:00 AM UTC
 

--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -45,4 +45,4 @@ jobs:
           viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
           ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
           installTics: true
-          additionalFlags: --excludePaths=lib/**
+          filelist: .github/tics-filelist.txt

--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           mode: qserver
           project: temporal-k8s-operator
-          branch: track/1.23
+          branchname: track/1.23
           branchdir: .
           viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
           ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}

--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -45,3 +45,4 @@ jobs:
           viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
           ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
           installTics: true
+          arguments: --excludePaths=lib/**

--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -14,10 +14,10 @@ jobs:
       - name: Checkout the project
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.12
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -3,6 +3,7 @@ name: TICS run self-hosted test (github-action)
 
 on:
   workflow_dispatch:  # allows manual trigger
+  pull_request:
   schedule:
     - cron: '0 4 * * 1'  # every Monday at 4 AM UTC
 

--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -1,35 +1,35 @@
-name: Tiobe TiCS Analysis
+name: TICS run self-hosted test (github-action)
 
 on:
-  workflow_dispatch:  # Manual trigger
-  pull_request:
+  workflow_dispatch: # Allows manual triggering
   schedule:
-    - cron: '0 4 * * 1'  # Every Monday at 4 AM UTC
+    - cron: "0 2 * * 6" # Every Saturday 2:00 AM UTC
 
 jobs:
-  tics:
-    name: TiCS Analysis
-    runs-on: [self-hosted, linus, amd64, tiobe, jammy]
+  build:
+    runs-on: [self-hosted, linux, amd64, tiobe, jammy]
 
     steps:
       - name: Checkout the project
         uses: actions/checkout@v4
 
-      - name: Set up Python
+      - name: Set up Python 3.8
         uses: actions/setup-python@v5
         with:
-          python-version: 3.x
+          python-version: 3.8
 
-      - name: Install test dependencies
+      - name: Install dependencies
         run: |
-          python3 -m pip install --upgrade pip
-          pip install coverage
+          pip install tox
+          pip install pylint flake8
 
-      - name: Run unit tests and generate coverage report
+      - name: Run tox tests to create coverage.xml
+        run: tox run -e unit
+
+      - name: Move results to necessary folder for TICS
         run: |
           mkdir -p .cover
-          coverage run -m unittest discover tests/
-          coverage xml -o .cover/cobertura.xml
+          mv coverage.xml .cover/coverage.xml
 
       - name: Run TICS analysis with github-action
         uses: tiobe/tics-github-action@v3

--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -22,10 +22,14 @@ jobs:
       - name: Install dependencies
         run: |
           pip install tox
-          pip install pylint flake8
+          pip install pylint flake8 coverage
 
       - name: Run tox tests to create coverage.xml
         run: tox run -e unit
+
+      - name: Generate coverage.xml
+        run: |
+          coverage xml -o coverage.xml
 
       - name: Move results to necessary folder for TICS
         run: |

--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -1,48 +1,13 @@
-name: TICS run self-hosted test (github-action)
+name: Tiobe TiCS Analysis
 
 on:
-  workflow_dispatch: # Allows manual triggering
-  pull_request:
-  schedule:
-    - cron: "0 2 * * 1" # Every Monday 2:00 AM UTC
+    pull_request:
+    workflow_dispatch:
+    schedule:
+    - cron: "17 2 * * 1"  # Runs at 2:17 UTC every Monday
 
 jobs:
-  build:
-    runs-on: [self-hosted, linux, amd64, tiobe, jammy]
-
-    steps:
-      - name: Checkout the project
-        uses: actions/checkout@v4
-
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.12
-
-      - name: Install dependencies
-        run: |
-          pip install tox
-          pip install pylint flake8 coverage
-
-      - name: Run tox tests to create coverage.xml
-        run: tox run -e unit
-
-      - name: Generate coverage.xml
-        run: |
-          coverage xml -o coverage.xml
-
-      - name: Move results to necessary folder for TICS
-        run: |
-          mkdir -p .cover
-          mv coverage.xml .cover/coverage.xml
-
-      - name: Run TICS analysis with github-action
-        uses: tiobe/tics-github-action@v3
-        with:
-          mode: qserver
-          project: temporal-k8s-operator
-          branchdir: .
-          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
-          ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
-          installTics: true
-          filelist: .github/tics-filelist.txt
+    tics:
+        name: TiCs
+        uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@main
+        secrets: inherit

--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -45,4 +45,4 @@ jobs:
           viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
           ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
           installTics: true
-          arguments: --excludePaths=lib/**
+          additionalFlags: --excludePaths=lib/**

--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -1,0 +1,24 @@
+name: TICS run self-hosted test (github-action)
+
+on:
+  workflow_dispatch:  # allows manual trigger
+  schedule:
+    - cron: '0 4 * * 1'  # every Monday at 4 AM UTC
+
+jobs:
+  run-tics-analysis:
+    runs-on: [self-hosted, amd64, tiobe, noble]
+
+    steps:
+      - name: Checkout the project
+        uses: actions/checkout@v4
+
+      - name: Run TICS analysis with github-action
+        uses: tiobe/tics-github-action@v3
+        with:
+          mode: qserver
+          project: temporal-k8s-operator
+          branchdir: .
+          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
+          ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
+          installTics: true

--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: [self-hosted, linux, amd64, tiobe, noble]
+    runs-on: [self-hosted, linux, amd64, tiobe, jammy]
 
     steps:
       - name: Checkout the project

--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -1,4 +1,3 @@
-#Force github to re-register workflow
 name: Tiobe TiCS Analysis
 
 on:
@@ -9,6 +8,35 @@ on:
 
 jobs:
   tics:
-    name: TiCS
-    uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@v1
-    secrets: inherit
+    name: TiCS Analysis
+    runs-on: [self-hosted, amd64, tiobe, noble]
+
+    steps:
+      - name: Checkout the project
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+
+      - name: Install test dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          pip install coverage
+
+      - name: Run unit tests and generate coverage report
+        run: |
+          mkdir -p .cover
+          coverage run -m unittest discover tests/
+          coverage xml -o .cover/cobertura.xml
+
+      - name: Run TICS analysis with github-action
+        uses: tiobe/tics-github-action@v3
+        with:
+          mode: qserver
+          project: temporal-k8s-operator
+          branchdir: .
+          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
+          ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
+          installTics: true

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 envlist = fmt, lint, unit, static, coverage-report
 skipsdist = True
 skip_missing_interpreters = True
-max-line-length=120
+max-line-length = 120
 
 [vars]
 src_path = {toxinidir}/src/
@@ -16,13 +16,14 @@ all_path = {[vars]src_path} {[vars]tst_path}
 [testenv]
 basepython = python3
 setenv =
-  PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
-  PYTHONBREAKPOINT=ipdb.set_trace
-  PY_COLORS=1
+    PYTHONPATH = {toxinidir}:{[vars]src_path}
+    COVERAGE_PROCESS_START = {toxinidir}/.coveragerc
+    PYTHONBREAKPOINT = ipdb.set_trace
+    PY_COLORS = 1
 passenv =
-  PYTHONPATH
-  CHARM_BUILD_DIR
-  MODEL_SETTINGS
+    PYTHONPATH
+    CHARM_BUILD_DIR
+    MODEL_SETTINGS
 
 [testenv:fmt]
 description = Format the code
@@ -53,14 +54,24 @@ deps =
     flake8-test-docs>=1.0
 commands =
     pydocstyle {[vars]src_path}
-    codespell {toxinidir} --skip {toxinidir}/.git --skip {toxinidir}/.tox \
-      --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
-      --skip {toxinidir}/.mypy_cache --skip {toxinidir}/icon.svg
+    codespell {toxinidir} \
+      --skip {toxinidir}/.git \
+      --skip {toxinidir}/.tox \
+      --skip {toxinidir}/build \
+      --skip {toxinidir}/lib \
+      --skip {toxinidir}/venv \
+      --skip {toxinidir}/.mypy_cache \
+      --skip {toxinidir}/icon.svg
     pflake8 {[vars]src_path} {[vars]tst_path}
     isort --check-only --diff {[vars]src_path} {[vars]tst_path}
     black --check --diff {[vars]src_path} {[vars]tst_path}
-    mypy {[vars]all_path} --ignore-missing-imports --follow-imports=skip --install-types --non-interactive
-    pylint {[vars]all_path} --disable=E0401,W1203,W0613,W0718,R0903,W1514,C0103,R0913,C0301,W0212,R0902,C0104,W0640,R0801,W0511,R0914,R0912,W0719,R0917
+    mypy {[vars]all_path} \
+      --ignore-missing-imports \
+      --follow-imports=skip \
+      --install-types \
+      --non-interactive
+    pylint {[vars]all_path} \
+      --disable=E0401,W1203,W0613,W0718,R0903,W1514,C0103,R0913,C0301,W0212,R0902,C0104,W0640,R0801,W0511,R0914,R0912,W0719,R0917
 
 [testenv:unit]
 description = Run tests
@@ -74,8 +85,10 @@ deps =
     ops[testing]==2.21.1
     -r{toxinidir}/requirements.txt
 commands =
-    coverage run --source={[vars]src_path} \
+    # collect coverage only for src/ and tests/, not lib/
+    coverage run --source={[vars]src_path},{[vars]tst_path} \
         -m pytest --ignore={[vars]tst_path}integration -v --tb native -s {posargs}
+    coverage xml -o coverage.xml
     coverage report
 
 [testenv:coverage-report]
@@ -93,6 +106,7 @@ deps =
     bandit[toml]
     -r{toxinidir}/requirements.txt
 commands =
+    # scan only src/ and tests/
     bandit -c {toxinidir}/pyproject.toml -r {[vars]src_path} {[vars]tst_path}
 
 [testenv:integration]
@@ -108,4 +122,7 @@ deps =
     grpcio-health-checking==1.73.1
     -r{toxinidir}/requirements.txt
 commands =
-    pytest --tb native --ignore={[vars]tst_path}unit --ignore={[vars]tst_path}scenario --log-cli-level=INFO -s {posargs}
+    pytest --tb native \
+        --ignore={[vars]tst_path}unit \
+        --ignore={[vars]tst_path}scenario \
+        --log-cli-level=INFO -s {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -10,13 +10,13 @@ max-line-length = 120
 [vars]
 src_path = {toxinidir}/src/
 tst_path = {toxinidir}/tests/
-lib_path = {toxinidir}/lib/ 
+lib_path = {toxinidir}/lib 
 all_path = {[vars]src_path} {[vars]tst_path}
 
 [testenv]
 basepython = python3
 setenv =
-    PYTHONPATH = {toxinidir}:{[vars]src_path}
+    PYTHONPATH = {toxinidir}:{[vars]src_path}:{[vars]lib_path}
     COVERAGE_PROCESS_START = {toxinidir}/.coveragerc
     PYTHONBREAKPOINT = ipdb.set_trace
     PY_COLORS = 1
@@ -35,6 +35,7 @@ commands =
     black {[vars]src_path} {[vars]tst_path}
 
 [testenv:lint]
+basepython = python3.10
 description = Lint the code
 deps =
     mypy
@@ -86,7 +87,7 @@ deps =
     -r{toxinidir}/requirements.txt
 commands =
     # collect coverage only for src/ and tests/, not lib/
-    coverage run --source={[vars]src_path},{[vars]tst_path} \
+    coverage run --source={[vars]src_path} \
         -m pytest --ignore={[vars]tst_path}integration -v --tb native -s {posargs}
     coverage xml -o coverage.xml
     coverage report

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ max-line-length=120
 [vars]
 src_path = {toxinidir}/src/
 tst_path = {toxinidir}/tests/
+lib_path = {toxinidir}/lib/ 
 all_path = {[vars]src_path} {[vars]tst_path}
 
 [testenv]


### PR DESCRIPTION
## Description
Added Static Code Analysis to the repo to run every Monday automatically or by manual trigger.

---
## Testing instructions
The workflow can be tested by manual trigger or by automated trigger at 2 UTC every Monday.

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
