### PR TITLE
[WF-92] Enable static code analysis (TIOBE) scans

### DIFF
--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -1,0 +1,15 @@
+name: Tiobe TiCS Analysis
+
+on:
+    pull_request: #triggering workflow
+    workflow_dispatch:
+    schedule:
+    - cron: "17 2 * * 1"  # Runs at 2:17 UTC every Monday
+
+jobs:
+    tics:
+        name: TiCs
+        uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@main
+        with: 
+            coverage-folder: ".cover"
+        secrets: inherit

--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
     tics:
         name: TiCs
-        uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@main
+        uses: arjun11-malik/observability/.github/workflows/charm-tiobe-scan.yaml@main
         with: 
             coverage-folder: ".cover"
         secrets: inherit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,13 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
+[project]
+name = "temporal-k8s-operator"
+version = "0.0"
 
 [tool.bandit]
 exclude_dirs = ["/venv/"]
 [tool.bandit.assert_used]
 skips = ["*/*test.py", "*/test_*.py", "*tests/*.py"]
-
 # Testing tools configuration
 [tool.coverage.run]
 branch = true

--- a/requirements-integrations.txt
+++ b/requirements-integrations.txt
@@ -1,0 +1,8 @@
+ipdb==0.13.9
+juju==3.5.2.1
+pytest==7.1.3
+pytest-operator==0.31.1
+pytest-asyncio==0.21
+temporalio==1.7.0
+grpcio==1.73.1
+grpcio-health-checking==1.73.1


### PR DESCRIPTION
## Description
Adding static code analysis for the repo


---
## Testing instructions
The workflow is triggered automatically at Monday at 02:00 UTC or by manual trigger



---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
