### PR TITLE
[WF-120] Use absolute paths in temporal-worker docs

### DIFF
--- a/documentation/tutorial/07-deploy-worker.md
+++ b/documentation/tutorial/07-deploy-worker.md
@@ -37,12 +37,12 @@ To create a custom container image for the worker, you need to build and publish
 
 1. Create a `rockcraft` project. You can use the [`rockcraft.yaml`](https://github.com/canonical/temporal-worker-k8s-operator/tree/main/resource_sample_py) as template.
 
-2. Ensure the `command` of the rock runs the worker script directly. For example, if `command: "./app/scripts/start-worker.sh"`:
+2. Ensure the `command` of the rock runs the worker script directly. For example, if `command: "/app/scripts/start-worker.sh"`:
 
 ```
 $ cat start-worker.sh
  
-python3 app/resource_sample/worker.py
+python3 /app/resource_sample/worker.py
 ```
 
 3. Ensure your activities and workflows are also included in the rock as the worker script needs access to them.


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
Doc updates to reflect change in https://github.com/canonical/temporal-worker-k8s-operator/pull/76
Change use of relative paths in worker image entrypoints to absolute paths

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->
n/a

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->
Will update discourse docs as soon as PR merged

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [x] Documentation updated
