### PR TITLE
tests: add pgbouncer integration tests

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -17,9 +17,10 @@ jobs:
       use-canonical-k8s: true
       channel: 1.33-classic/stable
       charmcraft-channel: latest/stable
-      modules: '["test_charm.py", "test_auth.py", "test_scaling.py", "test_server_upgrade.py", "test_upgrades.py"]'
+      modules: '["test_charm.py", "test_auth.py", "test_scaling.py", "test_server_upgrade.py", "test_upgrades.py", "test_pgbouncer.py"]'
       juju-channel: 3.6/stable
       self-hosted-runner: true
       self-hosted-runner-label: large
       self-hosted-runner-arch: x64
       self-hosted-runner-image: noble
+      test-timeout: 35

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -4,7 +4,9 @@
 
 """Temporal charm integration test helpers."""
 
+import datetime
 import logging
+import time
 from pathlib import Path
 
 import yaml
@@ -20,6 +22,9 @@ METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
 APP_NAME_ADMIN = "temporal-admin-k8s"
 APP_NAME_UI = "temporal-ui-k8s"
+PGBOUNCER_APP_NAME = "pgbouncer-k8s"
+POSTGRESQL_APP_NAME = "postgresql-k8s"
+PGBOUNCER_CHANNEL = "1/stable"
 
 
 async def scale(ops_test: OpsTest, app, units):
@@ -45,11 +50,12 @@ async def scale(ops_test: OpsTest, app, units):
     assert len(ops_test.model.applications[app].units) == units
 
 
-async def run_sample_workflow(ops_test: OpsTest):
+async def run_sample_workflow(ops_test: OpsTest, count=1):
     """Connects a client and runs a basic Temporal workflow.
 
     Args:
         ops_test: PyTest object.
+        count: Number of workflows to run.
     """
     url = await get_application_url(ops_test, application=APP_NAME, port=7233)
     logger.info("running workflow on app address: %s", url)
@@ -57,11 +63,23 @@ async def run_sample_workflow(ops_test: OpsTest):
     client = await Client.connect(url)
 
     # Run a worker for the workflow
+    start_time = time.time()
     async with Worker(client, task_queue="my-task-queue", workflows=[SayHello], activities=[say_hello]):
         name = "Jean-luc"
-        result = await client.execute_workflow(SayHello.run, name, id="my-workflow-id", task_queue="my-task-queue")
-        logger.info(f"result: {result}")
+        for i in range(count):
+            logger.info(f"running workflow #{i + 1}")
+            result = await client.execute_workflow(
+                SayHello.run,
+                name,
+                id="my-workflow-id",
+                task_queue="my-task-queue",
+                execution_timeout=datetime.timedelta(seconds=300),
+            )
+            logger.info(f"result: {result}")
         assert result == f"Hello, {name}!"
+
+    end_time = time.time()
+    logger.info(f"Finished executing {count} workflows in {end_time - start_time} seconds")
 
 
 async def create_default_namespace(ops_test: OpsTest):

--- a/tests/integration/test_pgbouncer.py
+++ b/tests/integration/test_pgbouncer.py
@@ -1,0 +1,70 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Temporal charm pgbouncer integration tests."""
+
+import logging
+
+import pytest
+import pytest_asyncio
+from conftest import POSTGRESQL_CHANNEL, TEMPORAL_CHANNEL
+from helpers import (
+    APP_NAME,
+    APP_NAME_ADMIN,
+    PGBOUNCER_APP_NAME,
+    PGBOUNCER_CHANNEL,
+    POSTGRESQL_APP_NAME,
+    create_default_namespace,
+    run_sample_workflow,
+)
+from pytest_operator.plugin import OpsTest
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.skip_if_deployed
+@pytest_asyncio.fixture(name="deploy", scope="module")
+async def deploy(ops_test: OpsTest):
+    """The app is up and running."""
+    # Deploy temporal server, temporal admin and postgresql charms.
+    await ops_test.model.deploy(APP_NAME, channel=TEMPORAL_CHANNEL, config={"num-history-shards": 1}, num_units=3)
+    await ops_test.model.deploy(POSTGRESQL_APP_NAME, channel=POSTGRESQL_CHANNEL, trust=True)
+    await ops_test.model.deploy(PGBOUNCER_APP_NAME, channel=PGBOUNCER_CHANNEL, trust=True)
+    await ops_test.model.deploy(APP_NAME_ADMIN, channel=TEMPORAL_CHANNEL)
+
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(
+            apps=[APP_NAME, APP_NAME_ADMIN, PGBOUNCER_APP_NAME],
+            status="blocked",
+            raise_on_blocked=False,
+            timeout=600,
+        )
+        await ops_test.model.wait_for_idle(
+            apps=[POSTGRESQL_APP_NAME], status="active", raise_on_blocked=False, timeout=90*10
+        )
+
+        await ops_test.model.integrate(PGBOUNCER_APP_NAME, POSTGRESQL_APP_NAME)
+
+        await ops_test.model.wait_for_idle(
+            apps=[POSTGRESQL_APP_NAME, PGBOUNCER_APP_NAME], status="active", raise_on_blocked=False, timeout=600
+        )
+
+        await ops_test.model.integrate(f"{APP_NAME}:db", f"{PGBOUNCER_APP_NAME}:database")
+        await ops_test.model.integrate(f"{APP_NAME}:visibility", f"{PGBOUNCER_APP_NAME}:database")
+        await ops_test.model.integrate(f"{APP_NAME}:admin", f"{APP_NAME_ADMIN}:admin")
+        await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", raise_on_blocked=False, timeout=180)
+
+        await create_default_namespace(ops_test)
+
+        await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", raise_on_blocked=False, timeout=300)
+        assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
+
+
+@pytest.mark.abort_on_fail
+@pytest.mark.usefixtures("deploy")
+class TestPgbouncer:
+    """Integration tests for Temporal charm."""
+
+    async def test_basic_client(self, ops_test: OpsTest):
+        """Connects a client and runs a basic Temporal workflow."""
+        await run_sample_workflow(ops_test)

--- a/tests/integration/test_pgbouncer.py
+++ b/tests/integration/test_pgbouncer.py
@@ -39,24 +39,18 @@ async def deploy(ops_test: OpsTest):
             raise_on_blocked=False,
             timeout=600,
         )
-        await ops_test.model.wait_for_idle(
-            apps=[POSTGRESQL_APP_NAME], status="active", raise_on_blocked=False, timeout=90*10
-        )
 
+        # Add integrations and wait for apps to become active and idle
         await ops_test.model.integrate(PGBOUNCER_APP_NAME, POSTGRESQL_APP_NAME)
-
-        await ops_test.model.wait_for_idle(
-            apps=[POSTGRESQL_APP_NAME, PGBOUNCER_APP_NAME], status="active", raise_on_blocked=False, timeout=600
-        )
-
         await ops_test.model.integrate(f"{APP_NAME}:db", f"{PGBOUNCER_APP_NAME}:database")
         await ops_test.model.integrate(f"{APP_NAME}:visibility", f"{PGBOUNCER_APP_NAME}:database")
         await ops_test.model.integrate(f"{APP_NAME}:admin", f"{APP_NAME_ADMIN}:admin")
-        await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", raise_on_blocked=False, timeout=180)
+        await ops_test.model.wait_for_idle(status="active", raise_on_blocked=False, timeout=90*10)
 
+        # Run action to create default namespace
         await create_default_namespace(ops_test)
 
-        await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", raise_on_blocked=False, timeout=300)
+        await ops_test.model.wait_for_idle(status="active", raise_on_blocked=False, timeout=300)
         assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
 
 

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -13,6 +13,9 @@ from helpers import (
     APP_NAME_ADMIN,
     APP_NAME_UI,
     METADATA,
+    PGBOUNCER_APP_NAME,
+    PGBOUNCER_CHANNEL,
+    POSTGRESQL_APP_NAME,
     create_default_namespace,
     run_sample_workflow,
     scale,
@@ -41,34 +44,53 @@ async def deploy(ops_test: OpsTest):
             charm,
             resources=resources,
             application_name=ALL_SERVICES[i],
-            config={"services": ALL_CONFIG[i], "num-history-shards": 1},
+            config={
+                "services": ALL_CONFIG[i],
+                "num-history-shards": 1,
+                "persistence-max-conns": 3,
+                "persistence-max-idle-conns": 3,
+                "visibility-max-conns": 5,
+                "visibility-max-idle-conns": 5,
+            },
         )
 
     await ops_test.model.deploy(APP_NAME_ADMIN, channel=TEMPORAL_CHANNEL)
     await ops_test.model.deploy(APP_NAME_UI, channel=TEMPORAL_CHANNEL)
-    await ops_test.model.deploy("postgresql-k8s", channel=POSTGRESQL_CHANNEL, trust=True)
+    await ops_test.model.deploy(POSTGRESQL_APP_NAME, channel=POSTGRESQL_CHANNEL, trust=True)
+    await ops_test.model.deploy(
+        PGBOUNCER_APP_NAME, channel=PGBOUNCER_CHANNEL, trust=True, config={"max_db_connections": 20}
+    )
 
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(
-            apps=[APP_NAME_ADMIN, APP_NAME_UI] + ALL_SERVICES, status="blocked", raise_on_blocked=False, timeout=1200
+            apps=[APP_NAME_ADMIN, APP_NAME_UI, PGBOUNCER_APP_NAME] + ALL_SERVICES,
+            status="blocked",
+            raise_on_blocked=False,
+            timeout=1200,
         )
         await ops_test.model.wait_for_idle(
-            apps=["postgresql-k8s"], status="active", raise_on_blocked=False, timeout=1200
+            apps=[POSTGRESQL_APP_NAME], status="active", raise_on_blocked=False, timeout=1200
+        )
+
+        await ops_test.model.integrate(PGBOUNCER_APP_NAME, POSTGRESQL_APP_NAME)
+
+        await ops_test.model.wait_for_idle(
+            apps=[POSTGRESQL_APP_NAME, PGBOUNCER_APP_NAME], status="active", raise_on_blocked=False, timeout=1200
         )
 
         for service in ALL_SERVICES:
             assert ops_test.model.applications[service].units[0].workload_status == "blocked"
 
         # Must integrate temporal-k8s frontend service first
-        await ops_test.model.integrate(f"{APP_NAME}:db", "postgresql-k8s:database")
-        await ops_test.model.integrate(f"{APP_NAME}:visibility", "postgresql-k8s:database")
+        await ops_test.model.integrate(f"{APP_NAME}:db", f"{PGBOUNCER_APP_NAME}:database")
+        await ops_test.model.integrate(f"{APP_NAME}:visibility", f"{PGBOUNCER_APP_NAME}:database")
         await ops_test.model.integrate(f"{APP_NAME}:admin", f"{APP_NAME_ADMIN}:admin")
         await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", raise_on_blocked=False, timeout=600)
 
         for service in ALL_SERVICES:
             if service != "temporal-k8s":
-                await ops_test.model.integrate(f"{service}:db", "postgresql-k8s:database")
-                await ops_test.model.integrate(f"{service}:visibility", "postgresql-k8s:database")
+                await ops_test.model.integrate(f"{service}:db", f"{PGBOUNCER_APP_NAME}:database")
+                await ops_test.model.integrate(f"{service}:visibility", f"{PGBOUNCER_APP_NAME}:database")
 
         await ops_test.model.wait_for_idle(apps=ALL_SERVICES, status="active", raise_on_blocked=False, timeout=1800)
 
@@ -95,11 +117,13 @@ class TestScaling:
         for service in ALL_SERVICES:
             await scale(ops_test, app=service, units=2)
 
-        await run_sample_workflow(ops_test)
+        # The count argument is an arbitrary number, keep it around 500 to allow
+        # runners to complete this number of runs before timeouts.
+        await run_sample_workflow(ops_test, count=500)
 
     async def test_scaling_down(self, ops_test: OpsTest):
         """Scale Temporal charm down to 1 unit."""
         for service in ALL_SERVICES:
             await scale(ops_test, app=service, units=1)
 
-        await run_sample_workflow(ops_test)
+        await run_sample_workflow(ops_test, count=500)


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

These test cases allow the integration with pgbouncer to be tested continuously. This commit introduces the following changes:

* Add tests/integration/test_pgbouncer.py
* Modify the test_scaling.py with max-conns and max-idle-conns values
* Add the test_pgbouncer.py as a target in the integration tests workflow
* Add a timeout to the integration tests workflow

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

Since this PR only affects tests, we can skip the manual testing.

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [x] Integration tests added or updated
- [ ] Documentation updated
