### PR TITLE
[WF-203] Use juju provider v1.0.0

### DIFF
--- a/terraform/justfile
+++ b/terraform/justfile
@@ -46,9 +46,11 @@ apply variables_file: (initialize)
 
 # Destroy the terraform plan with the provided variables file
 destroy variables_file:
+    #!/usr/bin/bash
     terraform destroy -auto-approve -var-file="${variables_file}"
 
     just destroy-model
+    sed '/model_uuid/d' -i "${variables_file}"
 
 test:
     #!/usr/bin/bash

--- a/terraform/justfile
+++ b/terraform/justfile
@@ -19,6 +19,15 @@ destroy-model:
 add-model: (destroy-model)
     juju add-model terraform
 
+[private]
+validate_test_tfvars variables_file:
+    #!/usr/bin/bash
+    MODEL_UUID=$(juju show-model terraform --format=json | jq -r '.terraform["model-uuid"]')
+    if ! juju show-model "${MODEL_UUID}" >/dev/null 2>&1; then
+        exit 1
+    fi
+    echo "model_uuid = \"${MODEL_UUID}\"" >> "${variables_file}"
+
 # Run terraform format
 fmt: (initialize)
     terraform fmt
@@ -48,6 +57,8 @@ test:
     trap 'just destroy "./test/test.tfvars"' EXIT
 
     just add-model
+
+    just validate_test_tfvars "./test/test.tfvars"
 
     just apply "./test/test.tfvars"
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,6 +1,11 @@
+data "juju_model" "terraform" {
+  name  = "terraform"
+  owner = "admin"
+}
+
 resource "juju_application" "temporal_k8s" {
-  name  = var.app_name
-  model_uuid = var.model_uuid
+  name       = var.app_name
+  model_uuid = data.juju_model.terraform.uuid
 
   charm {
     name     = "temporal-k8s"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,6 +1,6 @@
 resource "juju_application" "temporal_k8s" {
   name  = var.app_name
-  model = var.model
+  model_uuid = var.model_uuid
 
   charm {
     name     = "temporal-k8s"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,11 +1,11 @@
-data "juju_model" "terraform" {
-  name  = "terraform"
+data "juju_model" "terraform_model" {
+  name  = var.model
   owner = "admin"
 }
 
 resource "juju_application" "temporal_k8s" {
   name       = var.app_name
-  model_uuid = data.juju_model.terraform.uuid
+  model_uuid = data.juju_model.terraform_model.uuid
 
   charm {
     name     = "temporal-k8s"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,11 +1,6 @@
-data "juju_model" "terraform_model" {
-  name  = var.model
-  owner = "admin"
-}
-
 resource "juju_application" "temporal_k8s" {
   name       = var.app_name
-  model_uuid = data.juju_model.terraform_model.uuid
+  model_uuid = var.model_uuid
 
   charm {
     name     = "temporal-k8s"

--- a/terraform/test/test.tfvars
+++ b/terraform/test/test.tfvars
@@ -1,2 +1,1 @@
-model   = "terraform"
 channel = "1.23/edge"

--- a/terraform/test/test.tfvars
+++ b/terraform/test/test.tfvars
@@ -1,1 +1,2 @@
+model = "terraform"
 channel = "1.23/edge"

--- a/terraform/test/test.tfvars
+++ b/terraform/test/test.tfvars
@@ -1,2 +1,1 @@
-model = "terraform"
 channel = "1.23/edge"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -10,9 +10,9 @@ variable "units" {
   default     = 1
 }
 
-variable "model" {
-  type = string
-  description = "Juju model where the application is to be deployed"
+variable "model_uuid" {
+  type        = string
+  description = "UUID of Juju model where the application is to be deployed"
 }
 
 variable "revision" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -10,7 +10,7 @@ variable "units" {
   default     = 1
 }
 
-variable "model" {
+variable "model_uuid" {
   type        = string
   description = "Juju model where the application is to be deployed"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -10,11 +10,6 @@ variable "units" {
   default     = 1
 }
 
-variable "model_uuid" {
-  type        = string
-  description = "Juju model where the application is to be deployed"
-}
-
 variable "revision" {
   type        = number
   description = "Revision of the charm to deploy"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -10,6 +10,11 @@ variable "units" {
   default     = 1
 }
 
+variable "model" {
+  type = string
+  description = "Juju model where the application is to be deployed"
+}
+
 variable "revision" {
   type        = number
   description = "Revision of the charm to deploy"

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.21.1"
+      version = ">= 1.0.0"
     }
   }
 }


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
This PR updates the Terraform integration for the temporal-k8s-operator to use the new Juju provider v1.0.0, replaces the deprecated model attribute with model_uuid, and removes the need for specifying a model or UUID in the module inputs.

The model UUID is now resolved using the provider’s juju_model data source, ensuring that Terraform always deploys into the correct Juju model without requiring manual configuration or Justfile-injected values.
<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

## Key-Changes:
- Replace model attribute with `model_uuid`. 
-  New required field is `model_uuid = data.juju_model.terraform.uuid` 
- Introduce a `juju_model` data source to resolve model_uuid dynamically.
- Remove obsolete `model` variable declaration from `variables.tf`
- Upgrade provider version to v1.0.0
- `test/test.tfvars` no longer needs to declare `model = "terraform"`
---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
just validate
just fmt
just lint
just test

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
