### PR TITLE
[WF-121] fix for list-auth-rule action fails with namespace parameter

### DIFF
--- a/src/relations/openfga.py
+++ b/src/relations/openfga.py
@@ -11,7 +11,7 @@ from urllib.parse import urlsplit
 
 import requests
 from charms.openfga_k8s.v1.openfga import OpenFGAStoreCreateEvent
-from openfga_sdk import ReadRequestTupleKey, TupleKey
+from openfga_sdk import ReadRequestTupleKey
 from openfga_sdk.client import ClientConfiguration, OpenFgaClient
 from openfga_sdk.client.models.check_request import ClientCheckRequest
 from openfga_sdk.client.models.list_objects_request import ClientListObjectsRequest
@@ -224,14 +224,30 @@ class OpenFGA(framework.Object):
 
         user = event.params.get("user")
         group = event.params.get("group")
+        namespace = event.params.get("namespace")
         openfga_data = self.charm._state.openfga
 
         if user:
+            if not user.strip():
+                logger.error("list-auth-rule action failed: 'user' value cannot be empty")
+                event.fail("'user' value cannot be empty")
+                return
             asyncio.run(_list_user_auth_rules(event, openfga_data))
         elif group:
+            if not group.strip():
+                logger.error("list-auth-rule action failed: 'group' value cannot be empty")
+                event.fail("'group' value cannot be empty")
+                return
             asyncio.run(_list_group_auth_rules(event, openfga_data))
-        else:
+        elif namespace:
+            if not namespace.strip():
+                logger.error("list-auth-rule action failed: 'namespace' value cannot be empty")
+                event.fail("'namespace' value cannot be empty")
+                return
             asyncio.run(_list_namespace_auth_rules(event, openfga_data))
+        else:
+            logger.error("list-auth-rule action failed: one of 'user', 'group', or 'namespace' is required")
+            event.fail("one of 'user', 'group', or 'namespace' is required")
 
     @log_event_handler(logger)
     def _on_check_auth_rule_action(self, event):
@@ -599,7 +615,7 @@ async def _list_namespace_auth_rules(event, openfga_data):
     """
     try:
         results = {key: [] for key in ALLOWED_OFGA_ROLES}
-        body = TupleKey(
+        body = ReadRequestTupleKey(
             object=f"namespace:{event.params.get('namespace')}",
         )
 

--- a/tests/scenario/test_openfga_actions.py
+++ b/tests/scenario/test_openfga_actions.py
@@ -1,3 +1,6 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/tests/scenario/test_openfga_actions.py
+++ b/tests/scenario/test_openfga_actions.py
@@ -1,0 +1,65 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Scenario tests for OpenFGA actions validation."""
+
+import unittest.mock
+
+import ops.testing
+import pytest
+
+
+@pytest.fixture
+def action_state(
+    temporal_container,
+    peer_relation,
+    admin_relation,
+    db_relation,
+    visibility_relation,
+    nginx_route_relation,
+    openfga_relation,
+    s3_relation,
+    network,
+    openfga_secret,
+):
+    return ops.testing.State(
+        leader=True,
+        containers=[temporal_container],
+        config={"num-history-shards": 1, "auth-enabled": True},
+        relations=[
+            peer_relation,
+            admin_relation,
+            db_relation,
+            visibility_relation,
+            nginx_route_relation,
+            openfga_relation,
+            s3_relation,
+        ],
+        networks=[network],
+        secrets=[openfga_secret],
+    )
+
+
+class TestListAuthRuleActionValidation:
+    """Tests for list-auth-rule action input validation."""
+
+    @unittest.mock.patch("socket.gethostbyname", return_value="127.0.0.1")
+    def test_list_auth_rule_fails_with_empty_namespace(self, mock_dns, context, action_state):
+        with pytest.raises(ops.testing.ActionFailed) as exc_info:
+            context.run(context.on.action("list-auth-rule", params={"namespace": ""}), action_state)
+
+        assert "namespace" in str(exc_info.value).lower() or "empty" in str(exc_info.value).lower()
+
+    @unittest.mock.patch("socket.gethostbyname", return_value="127.0.0.1")
+    def test_list_auth_rule_fails_with_empty_user(self, mock_dns, context, action_state):
+        with pytest.raises(ops.testing.ActionFailed) as exc_info:
+            context.run(context.on.action("list-auth-rule", params={"user": ""}), action_state)
+
+        assert "user" in str(exc_info.value).lower() or "empty" in str(exc_info.value).lower()
+
+    @unittest.mock.patch("socket.gethostbyname", return_value="127.0.0.1")
+    def test_list_auth_rule_fails_with_empty_group(self, mock_dns, context, action_state):
+        with pytest.raises(ops.testing.ActionFailed) as exc_info:
+            context.run(context.on.action("list-auth-rule", params={"group": ""}), action_state)
+
+        assert "group" in str(exc_info.value).lower() or "empty" in str(exc_info.value).lower()


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
The _list_namespace_auth_rules function used TupleKey which requires the user parameter to be non-None. ReadRequestTupleKey is the correct class for read operations where user is optional.

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->
Closes #59 
---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [X] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
