### PR TITLE
docs: add OpenTelemetry Collector option for observability

### DIFF
--- a/documentation/how-to/observability.md
+++ b/documentation/how-to/observability.md
@@ -127,5 +127,3 @@ Metrics", make sure to select the juju model which contains your Temporal charm.
 The Temporal charm supports observability through either direct COS relations (shown above)
 or via [OpenTelemetry Collector](https://charmhub.io/opentelemetry-collector-k8s).
 Both use the same `prometheus_scrape` interface.
-
-> **Note:** `grafana-agent-k8s` is deprecated. Use `opentelemetry-collector-k8s` instead.

--- a/documentation/how-to/observability.md
+++ b/documentation/how-to/observability.md
@@ -121,3 +121,11 @@ juju run grafana/0 -m cos get-admin-password --wait 1m
 Grafana can be accessed on port 3000 of the app IP address (in our case, it will
 be `10.152.183.78:3000`). The dashboard can be accessed under "Temporal Server
 Metrics", make sure to select the juju model which contains your Temporal charm.
+
+## Using OpenTelemetry Collector
+
+The Temporal charm supports observability through either direct COS relations (shown above)
+or via [OpenTelemetry Collector](https://charmhub.io/opentelemetry-collector-k8s).
+Both use the same `prometheus_scrape` interface.
+
+> **Note:** `grafana-agent-k8s` is deprecated. Use `opentelemetry-collector-k8s` instead.


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
Add documentation for using OpenTelemetry Collector as an observability option

This change complements [charmed-temporal-solutions#15](https://github.com/canonical/charmed-temporal-solutions/pull/15) which migrated the Terraform modules from grafana-agent to otel-collector.

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [X] Documentation updated
