### PR TITLE
[WF-274] Skip TiCS workflow on fork PRs

### DIFF
--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -9,6 +9,8 @@ on:
 jobs:
     tics:
         name: TiCs
+        # Only run if we have access to secrets.
+        if: github.event_name != 'pull_request' || github.repository == github.event.pull_request.head.repo.full_name
         uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@main
         with: 
             coverage-folder: ".cover"


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
Skips the Tiobe TiCS Analysis workflow on PRs from forks so it doesn’t fail as fork PRs can’t use repo secrets.

# Changes
- Add `if` condition on the `tics` job: run only when `event_name != 'pull_request'` or when the PR head repo equals the workflow repo.

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->
Closes #124 

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
