### PR TITLE
ci(tests): grant read and write permissions to the tests workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,5 +15,9 @@ jobs:
       - name: Run promtool checks on Prometheus alert definitions
         run: promtool check rules $(find "$PWD" -name "*_rules.yaml")
   unit-tests:
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     uses: canonical/operator-workflows/.github/workflows/test.yaml@main
     secrets: inherit


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

Seems like the check-library action requires the following permissions to be able to modify PRs (e.g. by adding a label); w/o these permissions, it fails with Error: Resource not accessible by integration.

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->


This PR resolves the issue [here](https://github.com/canonical/temporal-k8s-operator/actions/runs/28475990566/job/84400592164). It is very similar to https://github.com/canonical/temporal-worker-k8s-operator/pull/109.

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
