### PR TITLE
Update maintainer email to workflows team

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -11,7 +11,7 @@ description: |
   Temporal is a developer-first, open source platform that ensures
   the successful execution of services and applications (using workflows).
 maintainers:
-  - Commercial Systems <jaas-crew@lists.canonical.com>
+  - Workflows Team <workflows-team@groups.canonical.com>
 source: https://github.com/canonical/temporal-k8s-operator
 docs: https://discourse.charmhub.io/t/temporal-server-documentation-overview/8948
 tags:


### PR DESCRIPTION
`metadata.yaml` listed the old "Commercial Systems" maintainer contact instead of the current owning team.

**Changes**
- Updated the `maintainers` field in `metadata.yaml` from `Commercial Systems <jaas-crew@lists.canonical.com>` to `Workflows Team <workflows-team@groups.canonical.com>`

Note: this issue calls for the same update across all `canonical/temporal-*` repositories; this PR covers `temporal-admin-k8s-operator` only, and corresponding changes will need separate PRs in the other repos.

<!-- START COPILOT CODING AGENT SUFFIX -->

Part of canonical/temporal-admin-k8s-operator#46