### PR TITLE
Update tutorial docs with missing juju relation

### DIFF
--- a/documentation/tutorial/05-deploy-admin.md
+++ b/documentation/tutorial/05-deploy-admin.md
@@ -47,6 +47,7 @@ temporal-k8s/0*        blocked   idle   10.1.0.152         admin:temporal relati
 Relate the admin interface:
 ```
 juju relate temporal-k8s:admin temporal-admin-k8s:admin
+juju integrate temporal-k8s:temporal-host-info temporal-admin-k8s:temporal-host-info
 ```
 Monitor relations until they settle:
 ```

--- a/documentation/tutorial/06-deploy-ui.md
+++ b/documentation/tutorial/06-deploy-ui.md
@@ -26,6 +26,7 @@ temporal-ui-k8s/0*  blocked   idle   10.1.0.111         ui:temporal relation: no
 
 ```
 juju integrate temporal-k8s:ui temporal-ui-k8s:ui
+juju integrate temporal-k8s:temporal-host-info temporal-ui-k8s:temporal-host-info 
 ```
 
 4. Wait for both charms to be active and idle


### PR DESCRIPTION
## Description

The current `temporal-admin-k8s` and `temporal-ui-k8s` charms require the `temporal-host-info` relation to learn the Temporal frontend address, but the tutorial only shows the `admin` and `ui` relations, so the `cli` action and the UI unit fail with `temporal-host-info relation not established`.
