### PR TITLE
[WF-519] ci: restore removed lib-checks action in track/1.31

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,6 +10,10 @@ jobs:
     name: Release tests
     uses: ./.github/workflows/tests.yaml
     secrets: inherit
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
 
   publish:
     name: 'Publish charm to edge | amd64'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,6 +25,27 @@ jobs:
       - name: Run promtool checks on Prometheus alert definitions
         run: promtool check rules $(find "$PWD" -name "*_rules.yaml")
 
+  lib-check:
+    name: Check libraries
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+      - name: Check libraries
+        id: checklibs
+        uses: canonical/charming-actions/check-libraries@2.7.0
+        with:
+          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          charm-path: "."
+
   lint:
     name: Lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
<!-- Reference the issue this PR addresses (e.g., Closes #123) -->
This PR address Enhancement Proposal #151 . It has the following changes:
1. Restores Charmhub library sync checks on `track/1.31` after they were removed in the CI refactor.
The `lib-check` job follows the pattern in [airflow-core-operators `tests.yaml`](https://github.com/canonical/airflow-core-operators/blob/track/3.1/.github/workflows/tests.yaml).
2. Job and reusable-workflow caller `permissions` follow [PR #142](https://github.com/canonical/temporal-k8s-operator/pull/142), which fixed `Error: Resource not accessible by integration` when `check-libraries` comments or labels a PR. 
3. The same scopes are set on `publish.yaml`’s `tests` job so they are not capped when `tests.yaml` is invoked via `workflow_call`.

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
4. Configure X with abc value
5. Integrate with Y charm
-->

1. Confirm this PR’s Tests workflow includes a `Check libraries` job.
2. With `lib/` in sync with Charmhub, that job should pass and must not fail with `Resource not accessible by integration`.


## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
